### PR TITLE
feat(auth): autentikasi & otorisasi user dengan better-auth (ISSUE-17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@ APP_NAME=KHENA
 # URL publik situs ini (dipakai untuk metadata/canonical, share link, dll)
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Base URL backend REST. Belum dipakai sampai ISSUE-15 (data layer masih mock) —
-# boleh dikosongkan untuk sekarang.
-NEXT_PUBLIC_API_BASE_URL=
+# Base URL backend REST (tanpa trailing slash, dengan /api). Wajib diisi —
+# dipakai langsung oleh browser untuk memanggil endpoint auth better-auth.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api
 
 # Nomor tujuan fallback checkout via WhatsApp, format 62xxxxxxxxxx (tanpa +/spasi).
 # JANGAN deploy ke produksi selagi nilainya masih placeholder di bawah ini.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Menjalankan bersama backend
+
+Autentikasi user (sign in, sign up, reset password, update profil) memanggil backend
+(`../khena-backend`) **langsung dari browser** — lihat `AGENTS.md` / issue ISSUE-17 untuk arsitektur
+lengkapnya. Untuk mengujinya secara lokal:
+
+1. Jalankan backend di `http://localhost:5000` (`bun install && bun run db:migrate && bun run dev`
+   di repo `khena-backend`).
+2. Jalankan frontend ini di `http://localhost:3000` (`bun dev`) — **port ini tidak boleh diganti
+   sembarangan**, karena sudah didaftarkan di `trustedOrigins`/`APP_PUBLIC_URL` backend. Request
+   dari origin lain akan ditolak CORS.
+3. Isi `NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api` di `.env` (lihat `.env.example`).
+
+Backend berjalan dengan `MAIL_DRIVER=console` di lokal, jadi email verifikasi/reset password
+**tidak benar-benar terkirim** — link-nya dicetak ke log terminal backend (cari baris
+`outgoing email (console driver)`). Salin link tersebut ke browser untuk melanjutkan alur lupa
+password.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:
@@ -34,3 +52,17 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+### Catatan deployment — autentikasi (ISSUE-17)
+
+- Backend wajib `COOKIE_SECURE=true` dan seluruh trafik lewat HTTPS.
+- Kalau website dan API berada di domain terdaftar yang **berbeda**
+  (mis. `khena.com` vs `khena-api.net`), cookie sesi `SameSite=Lax` **tidak akan terkirim** — backend
+  harus pindah ke `SameSite=None; Secure`. Kalau hanya beda subdomain (`khena.com` vs
+  `api.khena.com`), `Lax` tetap jalan.
+- `APP_PUBLIC_URL` di backend wajib diisi origin produksi frontend ini, kalau tidak semua request
+  auth ditolak CORS.
+- `MAIL_DRIVER` backend harus diganti dari `console` sebelum produksi, kalau tidak email reset
+  password tidak pernah benar-benar terkirim.
+- `NEXT_PUBLIC_API_BASE_URL` di frontend memang terekspos ke browser — itu wajar, isinya cuma URL
+  base API (request auth berangkat langsung dari browser ke backend, bukan lewat proxy Next.js).

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,16 @@
+import type {Metadata} from "next";
+import {RequireAuth} from "@/presentation/components/auth/require-auth";
+import {AccountPage} from "@/presentation/components/account/account-page";
+
+export const metadata: Metadata = {
+  title: "Account",
+  description: "Manage your Khena account.",
+};
+
+export default function Account() {
+  return (
+    <RequireAuth>
+      <AccountPage />
+    </RequireAuth>
+  );
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,4 +1,5 @@
 import type {Metadata} from "next";
+import {RequireAuth} from "@/presentation/components/auth/require-auth";
 import {CheckoutFlow} from "@/presentation/components/checkout/checkout-flow";
 
 export const metadata: Metadata = {
@@ -7,5 +8,9 @@ export const metadata: Metadata = {
 };
 
 export default function CheckoutPage() {
-  return <CheckoutFlow />;
+  return (
+    <RequireAuth>
+      <CheckoutFlow />
+    </RequireAuth>
+  );
 }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,27 @@
+import type {Metadata} from "next";
+import {Container} from "@/presentation/components/ui/container";
+import {Eyebrow} from "@/presentation/components/ui/eyebrow";
+import {ForgotPasswordForm} from "@/presentation/components/account/forgot-password-form";
+
+export const metadata: Metadata = {
+  title: "Forgot Password",
+  description: "Reset your Khena account password.",
+};
+
+export default function ForgotPasswordPage() {
+  return (
+    <Container className="py-20 lg:py-30">
+      <div className="mx-auto max-w-md">
+        <Eyebrow>Account</Eyebrow>
+        <h1 className="mt-4 font-display text-h2">Forgot Password</h1>
+        <p className="mt-4 text-sm text-muted">
+          Enter the email linked to your account and we&apos;ll send a link to reset your
+          password.
+        </p>
+        <div className="mt-10">
+          <ForgotPasswordForm />
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,28 @@
+import type {Metadata} from "next";
+import {Suspense} from "react";
+import {Container} from "@/presentation/components/ui/container";
+import {Eyebrow} from "@/presentation/components/ui/eyebrow";
+import {ResetPasswordForm} from "@/presentation/components/account/reset-password-form";
+
+export const metadata: Metadata = {
+  title: "Reset Password",
+  description: "Set a new password for your Khena account.",
+};
+
+export default function ResetPasswordPage() {
+  return (
+    <Container className="py-20 lg:py-30">
+      <div className="mx-auto max-w-md">
+        <Eyebrow>Account</Eyebrow>
+        <h1 className="mt-4 font-display text-h2">Reset Password</h1>
+        <div className="mt-10">
+          {/* useSearchParams (dipakai ResetPasswordForm) butuh boundary
+              Suspense supaya build statis Next 16 tidak gagal. */}
+          <Suspense fallback={null}>
+            <ResetPasswordForm />
+          </Suspense>
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.100.10",
         "axios": "^1.16.1",
+        "better-auth": "1.7.1",
         "next": "16.2.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -66,6 +67,24 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@better-auth/core": ["@better-auth/core@1.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.41.1", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.4.0", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A=="],
+
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0" }, "optionalPeers": ["drizzle-orm"] }, "sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw=="],
+
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ=="],
+
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2" } }, "sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ=="],
+
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA=="],
+
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A=="],
+
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ=="],
+
+    "@better-auth/utils": ["@better-auth/utils@0.4.2", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A=="],
+
+    "@better-fetch/fetch": ["@better-fetch/fetch@1.3.1", "", {}, "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -185,6 +204,10 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
+    "@noble/ciphers": ["@noble/ciphers@2.3.0", "", {}, "sha512-Clu/xdfgVTf9o7ngLOURaxePwR0j8sjclKEtVij10/jGulwFsPWCvvRgG/XjUVf8Nei+jLG6uwyXzUTGY1DQrw=="],
+
+    "@noble/hashes": ["@noble/hashes@2.3.0", "", {}, "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -193,7 +216,11 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -357,6 +384,10 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.30", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg=="],
 
+    "better-auth": ["better-auth@1.7.1", "", { "dependencies": { "@better-auth/core": "1.7.1", "@better-auth/drizzle-adapter": "1.7.1", "@better-auth/kysely-adapter": "1.7.1", "@better-auth/memory-adapter": "1.7.1", "@better-auth/mongo-adapter": "1.7.1", "@better-auth/prisma-adapter": "1.7.1", "@better-auth/telemetry": "1.7.1", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@noble/ciphers": "^2.2.0", "@noble/hashes": "^2.2.0", "better-call": "1.4.0", "defu": "^6.1.4", "jose": "^6.2.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.3.0", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg=="],
+
+    "better-call": ["better-call@1.4.0", "", { "dependencies": { "@better-auth/utils": "^0.5.0", "@better-fetch/fetch": "^1.3.1", "rou3": "^0.9.1", "set-cookie-parser": "^3.1.2" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA=="],
+
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -406,6 +437,8 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -617,6 +650,8 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
+    "jose": ["jose@6.2.9", "", {}, "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -634,6 +669,8 @@
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "kysely": ["kysely@0.29.5", "", {}, "sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
@@ -692,6 +729,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "nanostores": ["nanostores@1.5.1", "", {}, "sha512-DNIX+HyFpo14fKGe0NsX9/aPzdKGiSZwX5xEMpDwQrDdo2iTiUYunOCCQLYwJrziKVe8ZOtVvcv0dEVI8lMx2g=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
@@ -775,6 +814,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rou3": ["rou3@0.9.2", "", {}, "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
@@ -786,6 +827,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@3.1.2", "", {}, "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -918,6 +961,8 @@
     "@typescript-eslint/typescript-estree/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "better-call/@better-auth/utils": ["@better-auth/utils@0.5.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 

--- a/config/env.client.ts
+++ b/config/env.client.ts
@@ -1,8 +1,10 @@
 import {z} from "zod";
 
 const clientEnvSchema = z.object({
-  // Backend REST belum ada — dibiarkan optional sampai ISSUE-15.
-  NEXT_PUBLIC_API_BASE_URL: z.url().optional(),
+  // Wajib — dipakai langsung oleh browser untuk memanggil backend auth
+  // (better-auth). Salah konfigurasi harus ketahuan saat start, bukan saat
+  // user klik login.
+  NEXT_PUBLIC_API_BASE_URL: z.url(),
   NEXT_PUBLIC_APP_URL: z.url().optional(),
   NEXT_PUBLIC_WHATSAPP_ORDER_NUMBER: z.string().optional(),
 });

--- a/infrastructure/api/client.ts
+++ b/infrastructure/api/client.ts
@@ -7,6 +7,9 @@ export const apiClient: AxiosInstance = axios.create({
     "Content-Type": "application/json",
   },
   timeout: 15_000,
+  // Endpoint bisnis yang butuh sesi user mengandalkan cookie sesi dari
+  // better-auth — tanpa ini request lintas origin dianggap tamu.
+  withCredentials: true,
 });
 
 apiClient.interceptors.response.use(

--- a/infrastructure/api/client.ts
+++ b/infrastructure/api/client.ts
@@ -1,6 +1,28 @@
 import axios, {AxiosError, type AxiosInstance} from "axios";
 import {clientEnv} from "@/config/env.client";
 
+/**
+ * Error terstruktur dari `apiClient` — supaya pemanggil bisa membedakan 401
+ * (sesi habis/tidak ada) dari error lain lewat `isUnauthorized`, tanpa
+ * parsing pesan string (bagian Fase 9 issue.md).
+ *
+ * Sengaja TIDAK ada auto-redirect global di sini (mis. langsung membuka
+ * drawer sign in) — itu akan mengagetkan user yang sedang mengisi form.
+ * Pemanggil yang memutuskan sendiri mau menampilkan ajakan sign in seperti
+ * apa lewat flag ini.
+ */
+export class ApiError extends Error {
+  readonly status?: number;
+  readonly isUnauthorized: boolean;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.isUnauthorized = status === 401;
+  }
+}
+
 export const apiClient: AxiosInstance = axios.create({
   baseURL: clientEnv.NEXT_PUBLIC_API_BASE_URL,
   headers: {
@@ -19,7 +41,7 @@ apiClient.interceptors.response.use(
     const message =
       error.response?.data?.message ?? error.message ?? "Unknown API error";
     return Promise.reject(
-      new Error(`API error${status ? ` ${status}` : ""}: ${message}`)
+      new ApiError(`API error${status ? ` ${status}` : ""}: ${message}`, status)
     );
   }
 );

--- a/infrastructure/auth/auth-client.ts
+++ b/infrastructure/auth/auth-client.ts
@@ -1,0 +1,27 @@
+import {createAuthClient} from "better-auth/react";
+import {inferAdditionalFields} from "better-auth/client/plugins";
+import {clientEnv} from "@/config/env.client";
+
+/**
+ * Klien better-auth untuk auth USER (pengunjung website).
+ *
+ * baseURL wajib sudah menunjuk sampai `/auth`. Kalau hanya diberi
+ * `http://localhost:5000/api`, better-auth menganggap path itu sudah final
+ * (karena path-nya bukan "/") dan request akan menembak /api/sign-in/email —
+ * 404. Lihat `withPath()` di better-auth/dist/utils/url.mjs.
+ *
+ * `credentials: "include"` sudah jadi default klien ini, jadi cookie sesi ikut
+ * terkirim lintas origin tanpa konfigurasi tambahan.
+ */
+export const authClient = createAuthClient({
+  baseURL: `${clientEnv.NEXT_PUBLIC_API_BASE_URL}/auth`,
+  plugins: [
+    // Backend menambah field `phone` di luar bawaan better-auth. Tanpa plugin
+    // ini, `phone` tidak ada di tipe user maupun di payload signUp.
+    inferAdditionalFields({
+      user: {phone: {type: "string", required: true, input: true}},
+    }),
+  ],
+});
+
+export type AuthUser = typeof authClient.$Infer.Session.user;

--- a/infrastructure/auth/error-messages.ts
+++ b/infrastructure/auth/error-messages.ts
@@ -1,0 +1,25 @@
+/**
+ * Pemetaan kode error better-auth → kalimat untuk ditampilkan ke user.
+ *
+ * Backend sengaja memberi pesan generic saat login gagal (tidak membedakan
+ * "email tidak ada" vs "password salah") — pertahankan, jangan diperjelas,
+ * supaya tidak membocorkan email mana yang terdaftar.
+ */
+
+/** Dipakai kalau kode error tidak dikenal. */
+const FALLBACK = "Something went wrong. Please try again.";
+
+const MESSAGES: Record<string, string> = {
+  INVALID_EMAIL_OR_PASSWORD: "Invalid login — check your email and password and try again.",
+  USER_ALREADY_EXISTS: "An account with this email already exists.",
+  EMAIL_NOT_VERIFIED: "Email not confirmed — check your inbox for the verification link.",
+  INVALID_TOKEN: "This reset link is invalid or has expired. Request a new one.",
+};
+
+export function authErrorMessage(error?: {code?: string; message?: string} | null): string {
+  if (!error) return FALLBACK;
+  if (error.code && MESSAGES[error.code]) return MESSAGES[error.code];
+  // Pesan dari hook validasi backend (mis. "phone already exists") sudah layak
+  // ditampilkan apa adanya.
+  return error.message ?? FALLBACK;
+}

--- a/infrastructure/auth/error-messages.ts
+++ b/infrastructure/auth/error-messages.ts
@@ -11,7 +11,13 @@ const FALLBACK = "Something went wrong. Please try again.";
 
 const MESSAGES: Record<string, string> = {
   INVALID_EMAIL_OR_PASSWORD: "Invalid login — check your email and password and try again.",
-  USER_ALREADY_EXISTS: "An account with this email already exists.",
+  // Diverifikasi manual lewat sign-up dengan email yang sudah ada: kode
+  // sungguhannya USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL, bukan
+  // USER_ALREADY_EXISTS seperti tebakan awal — lihat bagian Fase 1 issue.md.
+  USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL: "An account with this email already exists.",
+  // Belum bisa diverifikasi manual — backend saat ini
+  // requireEmailVerification: false, jadi kode ini tidak mungkin muncul
+  // sampai Fase 7 (verifikasi email) diaktifkan di backend.
   EMAIL_NOT_VERIFIED: "Email not confirmed — check your inbox for the verification link.",
   INVALID_TOKEN: "This reset link is invalid or has expired. Request a new one.",
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.100.10",
     "axios": "^1.16.1",
+    "better-auth": "1.7.1",
     "next": "16.2.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/presentation/components/account/account-drawer.tsx
+++ b/presentation/components/account/account-drawer.tsx
@@ -17,7 +17,20 @@ import {useToast} from "@/presentation/providers/toast-provider";
 import {useSavedProducts} from "@/application/hooks/use-saved-products";
 import {formatIDR} from "@/presentation/lib/format";
 
-type GuestMode = "signin" | "register" | "confirm";
+type GuestMode = "signin" | "register";
+
+// Pesan validasi di bawah ini wajib identik dengan backend (bagian 5
+// issue.md / contract.md) supaya user tidak pernah lolos di client lalu
+// ditolak server dengan kalimat yang berbeda.
+const PASSWORD_MESSAGE =
+  "password must be at least 8 characters and contain a letter and a number";
+
+const passwordSchema = z
+  .string()
+  .min(8, PASSWORD_MESSAGE)
+  .max(128, PASSWORD_MESSAGE)
+  .regex(/[a-zA-Z]/, PASSWORD_MESSAGE)
+  .regex(/[0-9]/, PASSWORD_MESSAGE);
 
 const signInSchema = z.object({
   email: z.string().trim().min(1, "Email is required").email("Enter a valid email address"),
@@ -26,17 +39,26 @@ const signInSchema = z.object({
 type SignInValues = z.infer<typeof signInSchema>;
 
 const registerSchema = z.object({
-  name: z.string().trim().min(1, "Name is required"),
+  name: z
+    .string()
+    .trim()
+    .min(2, "Name must be between 2 and 255 characters")
+    .max(255, "Name must be between 2 and 255 characters"),
   email: z.string().trim().min(1, "Email is required").email("Enter a valid email address"),
-  password: z.string().min(6, "Password must be at least 6 characters"),
+  password: passwordSchema,
+  phone: z
+    .string()
+    .trim()
+    .max(20, "Enter a valid phone number")
+    .regex(/^\+?[0-9][0-9 -]{6,18}$/, "Enter a valid phone number"),
 });
 type RegisterValues = z.infer<typeof registerSchema>;
 
-/** Account drawer — empat mode (bagian 3.4 issue.md). */
+/** Account drawer — sign in / register lewat sesi better-auth (ISSUE-17). */
 export function AccountDrawer() {
   const {isOpen, close} = useUi();
   const open = isOpen("account");
-  const {user, signIn, register: registerAccount, signOut} = useAuth();
+  const {user, signIn, signUp, signOut} = useAuth();
   const {toast} = useToast();
   const savedProducts = useSavedProducts();
 
@@ -64,11 +86,7 @@ export function AccountDrawer() {
     setFormError(undefined);
     const result = await signIn(values.email, values.password);
     if (!result.ok) {
-      setFormError(
-        result.error === "email-not-confirmed"
-          ? "Email not confirmed — please check your inbox for the verification link."
-          : "Invalid login — check your email and password and try again."
-      );
+      setFormError(result.message);
       return;
     }
     toast("Signed in successfully.");
@@ -77,16 +95,21 @@ export function AccountDrawer() {
 
   async function handleRegister(values: RegisterValues) {
     setFormError(undefined);
-    const result = await registerAccount(values.name, values.email, values.password);
+    const result = await signUp(values);
     if (!result.ok) {
-      setFormError(result.error);
+      setFormError(result.message);
       return;
     }
-    setMode("confirm");
+    // Backend: autoSignIn === true + requireEmailVerification === false, jadi
+    // begitu signUp sukses user sudah punya sesi — sama seperti sign in.
+    // (Kalau verifikasi email diaktifkan nanti — Fase 7 issue.md — alur ini
+    // perlu layar konfirmasi lagi.)
+    toast("Account created — welcome to Khena.");
+    close();
   }
 
-  function handleSignOut() {
-    signOut();
+  async function handleSignOut() {
+    await signOut();
     toast("Signed out.");
     close();
   }
@@ -144,6 +167,13 @@ export function AccountDrawer() {
 
             <div className="mt-10 space-y-3 border-t border-hairline pt-6 text-sm">
               <Link
+                href="/account"
+                onClick={close}
+                className="block transition-colors duration-300 ease-brand hover:text-accent"
+              >
+                View Account
+              </Link>
+              <Link
                 href="/checkout"
                 onClick={close}
                 className="block transition-colors duration-300 ease-brand hover:text-accent"
@@ -161,17 +191,6 @@ export function AccountDrawer() {
 
             <Button variant="dark" className="mt-10 w-full" onClick={handleSignOut}>
               Sign Out
-            </Button>
-          </div>
-        ) : mode === "confirm" ? (
-          <div className="text-center">
-            <p className="font-display text-h3">Check Your Email</p>
-            <p className="mt-4 text-sm text-muted">
-              We&apos;ve sent a verification link to your inbox. Confirm your email to finish
-              setting up your account.
-            </p>
-            <Button variant="dark" className="mt-8 w-full" onClick={() => switchMode("signin")}>
-              Back to Sign In
             </Button>
           </div>
         ) : mode === "signin" ? (
@@ -199,6 +218,11 @@ export function AccountDrawer() {
               Sign In
             </Button>
             <p className="text-center text-xs text-muted">
+              <Link href="/forgot-password" onClick={close} className="underline">
+                Forgot password?
+              </Link>
+            </p>
+            <p className="text-center text-xs text-muted">
               New to Khena?{" "}
               <button type="button" className="underline" onClick={() => switchMode("register")}>
                 Create an account
@@ -217,6 +241,12 @@ export function AccountDrawer() {
               type="email"
               {...registerForm.register("email")}
               error={registerForm.formState.errors.email?.message}
+            />
+            <FormField
+              label="Phone"
+              type="tel"
+              {...registerForm.register("phone")}
+              error={registerForm.formState.errors.phone?.message}
             />
             <FormField
               label="Password"

--- a/presentation/components/account/account-page.tsx
+++ b/presentation/components/account/account-page.tsx
@@ -1,31 +1,80 @@
 "use client";
 
+import {useEffect, useState} from "react";
 import Link from "next/link";
+import {useForm} from "react-hook-form";
+import {zodResolver} from "@hookform/resolvers/zod";
+import {z} from "zod";
 import {Button} from "@/presentation/components/ui/button";
 import {Container} from "@/presentation/components/ui/container";
 import {Eyebrow} from "@/presentation/components/ui/eyebrow";
+import {FormField} from "@/presentation/components/ui/form-field";
 import {PlaceholderImage} from "@/presentation/components/ui/placeholder-image";
 import {useAuth} from "@/presentation/providers/auth-provider";
 import {useToast} from "@/presentation/providers/toast-provider";
 import {useSavedProducts} from "@/application/hooks/use-saved-products";
 import {formatIDR} from "@/presentation/lib/format";
 
+// Aturan sama dengan form register (bagian 5 issue.md / contract.md) — nama
+// & telepon divalidasi identik di manapun user bisa mengisinya.
+const profileSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(2, "Name must be between 2 and 255 characters")
+    .max(255, "Name must be between 2 and 255 characters"),
+  phone: z
+    .string()
+    .trim()
+    .max(20, "Enter a valid phone number")
+    .regex(/^\+?[0-9][0-9 -]{6,18}$/, "Enter a valid phone number"),
+});
+type ProfileValues = z.infer<typeof profileSchema>;
+
 /**
- * Halaman /account — identitas user dan Saved Pieces (Fase 4 issue.md).
- * Selalu dirender di dalam <RequireAuth>, jadi `user` sudah pasti ada.
+ * Halaman /account — identitas & form update profil, Saved Pieces, sign out
+ * (Fase 4 & 6 issue.md). Selalu dirender di dalam <RequireAuth>, jadi `user`
+ * sudah pasti ada begitu komponen ini benar-benar merender kontennya.
  */
 export function AccountPage() {
-  const {user, signOut} = useAuth();
+  const {user, signOut, updateProfile} = useAuth();
   const {toast} = useToast();
   const savedProducts = useSavedProducts();
+  const [profileError, setProfileError] = useState<string | undefined>();
 
-  // Narrow tipe saja — kondisi !user seharusnya tidak pernah tercapai karena
-  // RequireAuth sudah menahan render sampai sesi ada.
+  const profileForm = useForm<ProfileValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {name: user?.name ?? "", phone: user?.phone ?? ""},
+  });
+
+  // Sinkronkan form begitu sesi membawa nama/telepon baru (mis. setelah
+  // update sukses). Efek sengaja tidak berjalan saat update GAGAL — server
+  // menolak tanpa mengubah `user`, jadi isian yang sudah diketik tidak
+  // ter-reset (AC Fase 6: telepon duplikat tidak menghapus isian).
+  useEffect(() => {
+    if (!user) return;
+    profileForm.reset({name: user.name, phone: user.phone});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.name, user?.phone]);
+
+  // Hooks di atas harus tetap jalan tiap render (Rules of Hooks) — baru
+  // setelah itu boleh narrow tipe untuk JSX di bawah. Kondisi ini seharusnya
+  // tidak pernah tercapai karena RequireAuth menahan render sampai sesi ada.
   if (!user) return null;
 
   async function handleSignOut() {
     await signOut();
     toast("Signed out.");
+  }
+
+  async function handleUpdateProfile(values: ProfileValues) {
+    setProfileError(undefined);
+    const result = await updateProfile(values);
+    if (!result.ok) {
+      setProfileError(result.message);
+      return;
+    }
+    toast("Profile updated.");
   }
 
   return (
@@ -36,22 +85,32 @@ export function AccountPage() {
       <div className="mt-12 grid grid-cols-1 gap-16 lg:grid-cols-[1fr_1.4fr]">
         <div>
           <h2 className="text-xs uppercase tracking-label text-muted">Details</h2>
-          <dl className="mt-4 space-y-4 text-sm">
-            <div>
-              <dt className="text-xs text-muted">Name</dt>
-              <dd className="mt-1">{user.name}</dd>
-            </div>
-            <div>
-              <dt className="text-xs text-muted">Email</dt>
-              <dd className="mt-1">{user.email}</dd>
-            </div>
-            <div>
-              <dt className="text-xs text-muted">Phone</dt>
-              <dd className="mt-1">{user.phone}</dd>
-            </div>
-          </dl>
+          <form
+            onSubmit={profileForm.handleSubmit(handleUpdateProfile)}
+            noValidate
+            className="mt-4 space-y-6"
+          >
+            <FormField
+              label="Name"
+              {...profileForm.register("name")}
+              error={profileForm.formState.errors.name?.message}
+            />
+            {/* Email read-only — endpoint /update-user tidak menerima
+                perubahan email (bagian Fase 6 issue.md). */}
+            <FormField label="Email" value={user.email} disabled readOnly hint="Cannot be changed here." />
+            <FormField
+              label="Phone"
+              type="tel"
+              {...profileForm.register("phone")}
+              error={profileForm.formState.errors.phone?.message}
+            />
+            {profileError ? <p className="text-xs text-danger">{profileError}</p> : null}
+            <Button type="submit" variant="dark" disabled={profileForm.formState.isSubmitting}>
+              Save Changes
+            </Button>
+          </form>
 
-          <Button variant="dark" className="mt-10" onClick={handleSignOut}>
+          <Button variant="default" className="mt-10" onClick={handleSignOut}>
             Sign Out
           </Button>
         </div>

--- a/presentation/components/account/account-page.tsx
+++ b/presentation/components/account/account-page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import {Button} from "@/presentation/components/ui/button";
+import {Container} from "@/presentation/components/ui/container";
+import {Eyebrow} from "@/presentation/components/ui/eyebrow";
+import {PlaceholderImage} from "@/presentation/components/ui/placeholder-image";
+import {useAuth} from "@/presentation/providers/auth-provider";
+import {useToast} from "@/presentation/providers/toast-provider";
+import {useSavedProducts} from "@/application/hooks/use-saved-products";
+import {formatIDR} from "@/presentation/lib/format";
+
+/**
+ * Halaman /account — identitas user dan Saved Pieces (Fase 4 issue.md).
+ * Selalu dirender di dalam <RequireAuth>, jadi `user` sudah pasti ada.
+ */
+export function AccountPage() {
+  const {user, signOut} = useAuth();
+  const {toast} = useToast();
+  const savedProducts = useSavedProducts();
+
+  // Narrow tipe saja — kondisi !user seharusnya tidak pernah tercapai karena
+  // RequireAuth sudah menahan render sampai sesi ada.
+  if (!user) return null;
+
+  async function handleSignOut() {
+    await signOut();
+    toast("Signed out.");
+  }
+
+  return (
+    <Container className="py-16 lg:py-24">
+      <Eyebrow>My Account</Eyebrow>
+      <h1 className="mt-4 font-display text-h1">{user.name}</h1>
+
+      <div className="mt-12 grid grid-cols-1 gap-16 lg:grid-cols-[1fr_1.4fr]">
+        <div>
+          <h2 className="text-xs uppercase tracking-label text-muted">Details</h2>
+          <dl className="mt-4 space-y-4 text-sm">
+            <div>
+              <dt className="text-xs text-muted">Name</dt>
+              <dd className="mt-1">{user.name}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted">Email</dt>
+              <dd className="mt-1">{user.email}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted">Phone</dt>
+              <dd className="mt-1">{user.phone}</dd>
+            </div>
+          </dl>
+
+          <Button variant="dark" className="mt-10" onClick={handleSignOut}>
+            Sign Out
+          </Button>
+        </div>
+
+        <div>
+          <h2 className="text-xs uppercase tracking-label text-muted">Saved Pieces</h2>
+          {savedProducts.length === 0 ? (
+            <p className="mt-4 text-sm text-muted">Pieces you save will appear here.</p>
+          ) : (
+            <div className="mt-4 grid grid-cols-2 gap-6 sm:grid-cols-3">
+              {savedProducts.map((product) => (
+                <Link key={product.id} href={`/product/${product.id}`} className="block">
+                  <div className="aspect-square bg-warm">
+                    <PlaceholderImage label={product.name} />
+                  </div>
+                  <p className="mt-2 text-xs">{product.name}</p>
+                  <p className="text-xs text-muted">{formatIDR(product.price)}</p>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/presentation/components/account/forgot-password-form.tsx
+++ b/presentation/components/account/forgot-password-form.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {useState} from "react";
+import {useForm} from "react-hook-form";
+import {zodResolver} from "@hookform/resolvers/zod";
+import {z} from "zod";
+import {FormField} from "@/presentation/components/ui/form-field";
+import {Button} from "@/presentation/components/ui/button";
+import {authClient} from "@/infrastructure/auth/auth-client";
+import {authErrorMessage} from "@/infrastructure/auth/error-messages";
+import {clientEnv} from "@/config/env.client";
+
+const schema = z.object({
+  email: z.string().trim().min(1, "Email is required").email("Enter a valid email address"),
+});
+type Values = z.infer<typeof schema>;
+
+/**
+ * Form lupa password (Fase 5 issue.md). Selalu menampilkan pesan sukses yang
+ * sama setelah submit — baik email itu terdaftar atau tidak — supaya tidak
+ * membocorkan email mana yang punya akun.
+ */
+export function ForgotPasswordForm() {
+  const [submitted, setSubmitted] = useState(false);
+  const [formError, setFormError] = useState<string | undefined>();
+  const form = useForm<Values>({resolver: zodResolver(schema)});
+
+  async function handleSubmit(values: Values) {
+    setFormError(undefined);
+    // redirectTo diperiksa backend terhadap trustedOrigins — wajib diturunkan
+    // dari NEXT_PUBLIC_APP_URL (atau origin saat ini kalau env belum diisi),
+    // jangan di-hardcode.
+    const redirectTo = `${clientEnv.NEXT_PUBLIC_APP_URL ?? window.location.origin}/reset-password`;
+    const {error} = await authClient.requestPasswordReset({email: values.email, redirectTo});
+    if (error) {
+      setFormError(authErrorMessage(error));
+      return;
+    }
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <p className="text-sm text-muted">
+        If that email is registered, we&apos;ve sent a reset link.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={form.handleSubmit(handleSubmit)} noValidate className="space-y-6">
+      <FormField
+        label="Email"
+        type="email"
+        {...form.register("email")}
+        error={form.formState.errors.email?.message}
+      />
+      {formError ? <p className="text-xs text-danger">{formError}</p> : null}
+      <Button
+        type="submit"
+        variant="dark"
+        size="lg"
+        className="w-full"
+        disabled={form.formState.isSubmitting}
+      >
+        Send Reset Link
+      </Button>
+    </form>
+  );
+}

--- a/presentation/components/account/reset-password-form.tsx
+++ b/presentation/components/account/reset-password-form.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import {useState} from "react";
+import {useRouter, useSearchParams} from "next/navigation";
+import {useForm} from "react-hook-form";
+import {zodResolver} from "@hookform/resolvers/zod";
+import {z} from "zod";
+import {FormField} from "@/presentation/components/ui/form-field";
+import {Button} from "@/presentation/components/ui/button";
+import {TextLink} from "@/presentation/components/ui/text-link";
+import {authClient} from "@/infrastructure/auth/auth-client";
+import {authErrorMessage} from "@/infrastructure/auth/error-messages";
+import {useToast} from "@/presentation/providers/toast-provider";
+import {useUi} from "@/presentation/providers/ui-provider";
+
+// Pesan sama dengan skema register — aturan password backend identik di
+// /sign-up/email dan /reset-password (lihat validateNewPassword di backend).
+const PASSWORD_MESSAGE =
+  "password must be at least 8 characters and contain a letter and a number";
+
+const schema = z
+  .object({
+    password: z
+      .string()
+      .min(8, PASSWORD_MESSAGE)
+      .max(128, PASSWORD_MESSAGE)
+      .regex(/[a-zA-Z]/, PASSWORD_MESSAGE)
+      .regex(/[0-9]/, PASSWORD_MESSAGE),
+    confirmPassword: z.string().min(1, "Confirm your new password"),
+  })
+  .refine((values) => values.password === values.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+type Values = z.infer<typeof schema>;
+
+/**
+ * Form set password baru (Fase 5 issue.md). Dibungkus <Suspense> oleh
+ * pemanggilnya — `useSearchParams` butuh itu di Next 16 untuk build statis.
+ */
+export function ResetPasswordForm() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const {toast} = useToast();
+  const {open} = useUi();
+  const [formError, setFormError] = useState<string | undefined>();
+
+  const token = searchParams.get("token");
+  const urlError = searchParams.get("error");
+
+  const form = useForm<Values>({resolver: zodResolver(schema)});
+
+  // Token kosong atau backend menandai link rusak/kedaluwarsa lewat
+  // ?error=... — tampilkan ajakan minta link baru, bukan form atau halaman
+  // kosong.
+  if (urlError || !token) {
+    return (
+      <div>
+        <p className="text-sm text-muted">
+          This reset link is invalid or has expired. Request a new one below.
+        </p>
+        <div className="mt-6">
+          <TextLink href="/forgot-password">REQUEST A NEW LINK</TextLink>
+        </div>
+      </div>
+    );
+  }
+
+  async function handleSubmit(values: Values) {
+    setFormError(undefined);
+    const {error} = await authClient.resetPassword({
+      token: token as string,
+      newPassword: values.password,
+    });
+    if (error) {
+      setFormError(authErrorMessage(error));
+      return;
+    }
+    toast("Password updated.");
+    router.push("/");
+    open("account");
+  }
+
+  return (
+    <form onSubmit={form.handleSubmit(handleSubmit)} noValidate className="space-y-6">
+      <FormField
+        label="New Password"
+        type="password"
+        {...form.register("password")}
+        error={form.formState.errors.password?.message}
+      />
+      <FormField
+        label="Confirm Password"
+        type="password"
+        {...form.register("confirmPassword")}
+        error={form.formState.errors.confirmPassword?.message}
+      />
+      {formError ? <p className="text-xs text-danger">{formError}</p> : null}
+      <Button
+        type="submit"
+        variant="dark"
+        size="lg"
+        className="w-full"
+        disabled={form.formState.isSubmitting}
+      >
+        Update Password
+      </Button>
+    </form>
+  );
+}

--- a/presentation/components/auth/require-auth.tsx
+++ b/presentation/components/auth/require-auth.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type {ReactNode} from "react";
+import {Icon} from "@/presentation/components/icon";
+import {ICONS} from "@/presentation/components/icons";
+import {Button} from "@/presentation/components/ui/button";
+import {Container} from "@/presentation/components/ui/container";
+import {useAuth} from "@/presentation/providers/auth-provider";
+import {useUi} from "@/presentation/providers/ui-provider";
+
+/**
+ * Guard UX untuk halaman yang butuh sesi. INI BUKAN LAPISAN KEAMANAN —
+ * penegakan sesungguhnya ada di backend yang menolak request tanpa cookie
+ * sesi. Guard ini hanya mencegah user melihat kerangka halaman kosong
+ * (bagian 3 keputusan #4 issue.md).
+ */
+export function RequireAuth({children}: {children: ReactNode}) {
+  const {user, isPending} = useAuth();
+  const {open} = useUi();
+
+  // Sesi belum selesai diambil dari server — render placeholder netral, jangan
+  // kedip antara ajakan sign in dan konten.
+  if (isPending) {
+    return <Container className="py-24" aria-hidden="true" />;
+  }
+
+  if (!user) {
+    return (
+      <Container className="flex flex-col items-center py-24 text-center">
+        <Icon icon={ICONS.lock} className="size-8 text-faint" />
+        <h1 className="mt-6 font-display text-h3">Sign in to continue</h1>
+        <p className="mt-4 max-w-sm text-sm text-muted">
+          You need to be signed in to view this page.
+        </p>
+        <Button variant="dark" size="lg" className="mt-8" onClick={() => open("account")}>
+          Sign In
+        </Button>
+      </Container>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/presentation/components/checkout/checkout-flow.tsx
+++ b/presentation/components/checkout/checkout-flow.tsx
@@ -19,9 +19,6 @@ import {WhatsAppPaymentGateway} from "@/infrastructure/payment/whatsapp-payment-
 import {useCart} from "@/presentation/providers/cart-provider";
 import {useUi} from "@/presentation/providers/ui-provider";
 
-// TODO(ISSUE-14): ganti dengan AuthProvider (status login sungguhan).
-const TEMP_IS_LOGGED_IN = false;
-
 type Step = "details" | "review";
 
 // Field yang divalidasi sebelum boleh lanjut dari step "details" ke "review".
@@ -152,19 +149,9 @@ export function CheckoutFlow() {
         <span className={step === "review" ? "text-ink" : undefined}>Review</span>
       </nav>
 
-      {!TEMP_IS_LOGGED_IN ? (
-        <div className="mt-8 border border-hairline bg-warm p-6">
-          <p className="text-sm">Save this to your account</p>
-          <ul className="mt-2 space-y-1 text-xs text-muted">
-            <li>Track your delivery in real time</li>
-            <li>View and repeat past purchases</li>
-            <li>Save pieces to your wishlist</li>
-          </ul>
-          <TextLink onClick={() => openOverlay("account")} className="mt-3 inline-block">
-            Create Account or Sign In →
-          </TextLink>
-        </div>
-      ) : null}
+      {/* Banner "Save this to your account" untuk tamu dihapus di ISSUE-17:
+          halaman /checkout sekarang dibungkus <RequireAuth>, jadi
+          CheckoutFlow tidak pernah dirender untuk tamu lagi. */}
 
       <div className="mt-10 grid grid-cols-1 gap-12 lg:grid-cols-[minmax(0,1fr)_400px]">
         {/* Order Summary tampil duluan di mobile (di atas form) supaya

--- a/presentation/components/product/wishlist-button.tsx
+++ b/presentation/components/product/wishlist-button.tsx
@@ -5,7 +5,6 @@ import type {MouseEvent} from "react";
 import {Icon} from "@/presentation/components/icon";
 import {ICONS} from "@/presentation/components/icons";
 import {cn} from "@/presentation/lib/cn";
-import {useAuth} from "@/presentation/providers/auth-provider";
 import {useWishlist} from "@/presentation/providers/wishlist-provider";
 
 export type WishlistButtonProps = {
@@ -16,16 +15,17 @@ export type WishlistButtonProps = {
 
 /**
  * Tombol wishlist — komponen terpisah dari ProductCard (bagian 6.2 issue.md).
- * Hook selalu dipanggil di urutan yang sama baik user login maupun tidak;
- * baru setelah itu komponen boleh merender `null` kalau belum login.
+ *
+ * Sengaja TIDAK digerbang oleh status login (beda dari sebelum ISSUE-17):
+ * tamu boleh menyimpan wishlist lokal (`khena.wishlist.guest`) yang nanti
+ * digabung otomatis ke akun begitu dia sign in — lihat wishlist-provider.tsx
+ * bagian 8a issue.md. Menyembunyikan tombol ini untuk tamu akan membuat fitur
+ * itu tidak pernah bisa dipakai dari UI.
  */
 export function WishlistButton({productId, productName, className}: WishlistButtonProps) {
-  const {user} = useAuth();
   const {isSaved, toggle} = useWishlist();
   const [pulse, setPulse] = useState<"save" | "remove" | null>(null);
   const saved = isSaved(productId);
-
-  if (!user) return null;
 
   function handleClick(event: MouseEvent<HTMLButtonElement>) {
     event.preventDefault();

--- a/presentation/providers/auth-provider.tsx
+++ b/presentation/providers/auth-provider.tsx
@@ -27,7 +27,7 @@ const AuthContext = createContext<AuthContextValue | null>(null);
  * sendiri untuk sesi (bagian 3 keputusan #3 issue.md).
  */
 export function AuthProvider({children}: {children: ReactNode}) {
-  const {data, isPending} = authClient.useSession();
+  const {data, isPending, refetch} = authClient.useSession();
   const user = data?.user ?? null;
 
   const signIn = useCallback(async (email: string, password: string): Promise<Result> => {
@@ -55,9 +55,13 @@ export function AuthProvider({children}: {children: ReactNode}) {
     async (input: {name?: string; phone?: string}): Promise<Result> => {
       const {error} = await authClient.updateUser(input);
       if (error) return {ok: false, message: authErrorMessage(error)};
+      // Klien better-auth biasanya memperbarui cache sesi sendiri, tapi
+      // di-refetch eksplisit sebagai jaring pengaman — bukan
+      // `window.location.reload()` (bagian Fase 6 issue.md).
+      refetch();
       return {ok: true};
     },
-    []
+    [refetch]
   );
 
   const value = useMemo<AuthContextValue>(

--- a/presentation/providers/auth-provider.tsx
+++ b/presentation/providers/auth-provider.tsx
@@ -1,93 +1,71 @@
 "use client";
 
-import {createContext, useCallback, useContext, useEffect, useState} from "react";
+import {createContext, useCallback, useContext, useMemo} from "react";
 import type {ReactNode} from "react";
+import {authClient, type AuthUser} from "@/infrastructure/auth/auth-client";
+import {authErrorMessage} from "@/infrastructure/auth/error-messages";
 
-export type AuthUser = {
-  id: string;
-  name: string;
-  email: string;
-};
+export type {AuthUser};
 
-export type SignInError = "invalid-login" | "email-not-confirmed";
-
-type SignInResult = {ok: true} | {ok: false; error: SignInError};
-type RegisterResult = {ok: true} | {ok: false; error: string};
+type Result = {ok: true} | {ok: false; message: string};
 
 type AuthContextValue = {
   user: AuthUser | null;
-  isHydrated: boolean;
-  signIn: (email: string, password: string) => Promise<SignInResult>;
-  register: (name: string, email: string, password: string) => Promise<RegisterResult>;
-  signOut: () => void;
+  /** true selama sesi masih diambil dari server — render UI netral dulu. */
+  isPending: boolean;
+  signIn: (email: string, password: string) => Promise<Result>;
+  signUp: (input: {name: string; email: string; password: string; phone: string}) => Promise<Result>;
+  signOut: () => Promise<void>;
+  updateProfile: (input: {name?: string; phone?: string}) => Promise<Result>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-const STORAGE_KEY = "khena.auth-user";
 
-// TODO(ISSUE-15): ganti dengan panggilan API auth sungguhan.
-// "demo@khena.co.id" / "khena123" sudah terverifikasi, untuk uji alur sign in.
-const MOCK_ACCOUNTS: {email: string; password: string; name: string; confirmed: boolean}[] = [
-  {email: "demo@khena.co.id", password: "khena123", name: "Demo User", confirmed: true},
-];
-
+/**
+ * Sesi dibaca dari satu sumber kebenaran: `authClient.useSession()`. Provider
+ * ini hanya pembungkus tipis di atasnya — tidak ada state atau localStorage
+ * sendiri untuk sesi (bagian 3 keputusan #3 issue.md).
+ */
 export function AuthProvider({children}: {children: ReactNode}) {
-  const [user, setUser] = useState<AuthUser | null>(null);
-  const [isHydrated, setIsHydrated] = useState(false);
+  const {data, isPending} = authClient.useSession();
+  const user = data?.user ?? null;
 
-  // Baca sesi dari localStorage setelah mount supaya tidak ada hydration mismatch.
-  useEffect(() => {
-    queueMicrotask(() => {
-      try {
-        const raw = window.localStorage.getItem(STORAGE_KEY);
-        if (raw) setUser(JSON.parse(raw) as AuthUser);
-      } catch {
-        // localStorage tidak tersedia atau datanya korup — mulai tanpa sesi.
-      } finally {
-        setIsHydrated(true);
-      }
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!isHydrated) return;
-    if (user) {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
-    } else {
-      window.localStorage.removeItem(STORAGE_KEY);
-    }
-  }, [user, isHydrated]);
-
-  const signIn = useCallback(async (email: string, password: string): Promise<SignInResult> => {
-    const account = MOCK_ACCOUNTS.find((a) => a.email.toLowerCase() === email.toLowerCase());
-    if (!account || account.password !== password) {
-      return {ok: false, error: "invalid-login"};
-    }
-    if (!account.confirmed) {
-      return {ok: false, error: "email-not-confirmed"};
-    }
-    setUser({id: account.email, name: account.name, email: account.email});
+  const signIn = useCallback(async (email: string, password: string): Promise<Result> => {
+    const {error} = await authClient.signIn.email({email, password});
+    if (error) return {ok: false, message: authErrorMessage(error)};
     return {ok: true};
   }, []);
 
-  const register = useCallback(
-    async (name: string, email: string, password: string): Promise<RegisterResult> => {
-      if (MOCK_ACCOUNTS.some((a) => a.email.toLowerCase() === email.toLowerCase())) {
-        return {ok: false, error: "An account with this email already exists."};
-      }
-      MOCK_ACCOUNTS.push({email, password, name, confirmed: false});
+  const signUp = useCallback(
+    async (input: {name: string; email: string; password: string; phone: string}): Promise<Result> => {
+      const {error} = await authClient.signUp.email(input);
+      if (error) return {ok: false, message: authErrorMessage(error)};
       return {ok: true};
     },
     []
   );
 
-  const signOut = useCallback(() => setUser(null), []);
+  const signOut = useCallback(async () => {
+    // Sesi di-refetch otomatis oleh authClient setelah sign out — tidak ada
+    // state lokal yang perlu direset manual.
+    await authClient.signOut();
+  }, []);
 
-  return (
-    <AuthContext.Provider value={{user, isHydrated, signIn, register, signOut}}>
-      {children}
-    </AuthContext.Provider>
+  const updateProfile = useCallback(
+    async (input: {name?: string; phone?: string}): Promise<Result> => {
+      const {error} = await authClient.updateUser(input);
+      if (error) return {ok: false, message: authErrorMessage(error)};
+      return {ok: true};
+    },
+    []
   );
+
+  const value = useMemo<AuthContextValue>(
+    () => ({user, isPending, signIn, signUp, signOut, updateProfile}),
+    [user, isPending, signIn, signUp, signOut, updateProfile]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {

--- a/presentation/providers/wishlist-provider.tsx
+++ b/presentation/providers/wishlist-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {createContext, useCallback, useContext, useEffect, useMemo, useState} from "react";
+import {createContext, useCallback, useContext, useEffect, useMemo, useRef, useState} from "react";
 import type {ReactNode} from "react";
 import {useAuth} from "@/presentation/providers/auth-provider";
 
@@ -12,36 +12,92 @@ type WishlistContextValue = {
 
 const WishlistContext = createContext<WishlistContextValue | null>(null);
 
+/** Wishlist tamu (belum login) — digabung ke wishlist user saat login. */
+const GUEST_STORAGE_KEY = "khena.wishlist.guest";
+
 function storageKey(userId: string) {
   return `khena.wishlist.${userId}`;
 }
 
-/** Wishlist per pengguna, disimpan lokal sampai backend siap (ISSUE-15). */
+function readList(key: string): string[] {
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Wishlist per pengguna.
+ *
+ * PENYIMPANAN SEMENTARA (bagian 8a/8b issue.md): masih di localStorage,
+ * karena belum ada satu pun endpoint bisnis yang memakai sesi user
+ * (`contract.md` tidak memuat endpoint wishlist). Begitu endpoint server ada,
+ * provider ini pindah ke React Query dengan optimistic update, dan
+ * localStorage hanya dipakai untuk tamu.
+ *
+ * `user.id` di sini sudah UUID asli dari `auth_users` (bukan email mock
+ * seperti sebelum ISSUE-17), jadi key localStorage tidak lagi berubah kalau
+ * user ganti email.
+ */
 export function WishlistProvider({children}: {children: ReactNode}) {
   const {user, isPending: authIsPending} = useAuth();
   const [productIds, setProductIds] = useState<string[]>([]);
 
+  // Key localStorage yang datanya sedang direpresentasikan oleh `productIds`.
+  // Efek tulis di bawah menahan diri sampai ini cocok dengan key aktif —
+  // tanpa ini, array kosong dari state awal akan menimpa data tersimpan
+  // sebelum proses baca (async, lewat queueMicrotask) sempat selesai.
+  const loadedKeyRef = useRef<string | null>(null);
+  // Melacak user.id yang wishlist tamunya sudah pernah digabung, supaya
+  // penggabungan hanya terjadi sekali per transisi tamu→login.
+  const mergedForUserId = useRef<string | null>(null);
+
   useEffect(() => {
-    // Masih menunggu sesi dari server — jangan baca/tulis dulu supaya tidak
-    // menimpa wishlist dengan state kosong.
     if (authIsPending) return;
+    const activeKey = user ? storageKey(user.id) : GUEST_STORAGE_KEY;
+
     queueMicrotask(() => {
       if (!user) {
-        setProductIds([]);
+        mergedForUserId.current = null;
+        setProductIds(readList(GUEST_STORAGE_KEY));
+        loadedKeyRef.current = activeKey;
         return;
       }
-      try {
-        const raw = window.localStorage.getItem(storageKey(user.id));
-        setProductIds(raw ? (JSON.parse(raw) as string[]) : []);
-      } catch {
-        setProductIds([]);
+
+      if (mergedForUserId.current === user.id) {
+        // Sudah pernah digabung untuk user ini — baca langsung, jangan
+        // gabung ulang (mis. saat productIds berubah karena toggle).
+        setProductIds(readList(activeKey));
+        loadedKeyRef.current = activeKey;
+        return;
       }
+
+      // Baru login: gabungkan wishlist tamu (union, tanpa duplikat) ke
+      // wishlist user, lalu hapus key tamu — supaya item yang disimpan
+      // sebelum login tidak hilang diam-diam.
+      const guestIds = readList(GUEST_STORAGE_KEY);
+      const userIds = readList(activeKey);
+      const merged =
+        guestIds.length === 0 ? userIds : Array.from(new Set([...userIds, ...guestIds]));
+
+      if (guestIds.length > 0) {
+        window.localStorage.setItem(activeKey, JSON.stringify(merged));
+        window.localStorage.removeItem(GUEST_STORAGE_KEY);
+      }
+
+      mergedForUserId.current = user.id;
+      setProductIds(merged);
+      loadedKeyRef.current = activeKey;
     });
   }, [user, authIsPending]);
 
   useEffect(() => {
-    if (authIsPending || !user) return;
-    window.localStorage.setItem(storageKey(user.id), JSON.stringify(productIds));
+    if (authIsPending) return;
+    const activeKey = user ? storageKey(user.id) : GUEST_STORAGE_KEY;
+    if (loadedKeyRef.current !== activeKey) return;
+    window.localStorage.setItem(activeKey, JSON.stringify(productIds));
   }, [productIds, user, authIsPending]);
 
   const isSaved = useCallback(

--- a/presentation/providers/wishlist-provider.tsx
+++ b/presentation/providers/wishlist-provider.tsx
@@ -18,11 +18,13 @@ function storageKey(userId: string) {
 
 /** Wishlist per pengguna, disimpan lokal sampai backend siap (ISSUE-15). */
 export function WishlistProvider({children}: {children: ReactNode}) {
-  const {user, isHydrated: authHydrated} = useAuth();
+  const {user, isPending: authIsPending} = useAuth();
   const [productIds, setProductIds] = useState<string[]>([]);
 
   useEffect(() => {
-    if (!authHydrated) return;
+    // Masih menunggu sesi dari server — jangan baca/tulis dulu supaya tidak
+    // menimpa wishlist dengan state kosong.
+    if (authIsPending) return;
     queueMicrotask(() => {
       if (!user) {
         setProductIds([]);
@@ -35,12 +37,12 @@ export function WishlistProvider({children}: {children: ReactNode}) {
         setProductIds([]);
       }
     });
-  }, [user, authHydrated]);
+  }, [user, authIsPending]);
 
   useEffect(() => {
-    if (!authHydrated || !user) return;
+    if (authIsPending || !user) return;
     window.localStorage.setItem(storageKey(user.id), JSON.stringify(productIds));
-  }, [productIds, user, authHydrated]);
+  }, [productIds, user, authIsPending]);
 
   const isSaved = useCallback(
     (productId: string) => productIds.includes(productId),


### PR DESCRIPTION
Closes #24.

## Ringkasan

Mengganti auth palsu (`MOCK_ACCOUNTS` + sesi `localStorage`) dengan sesi
sungguhan lewat `better-auth` (`better-auth@1.7.1`, sama dengan versi backend),
sesuai keputusan arsitektur di ISSUE-17: browser memanggil backend langsung
(cookie lintas origin), tidak ada proxy/route handler auth di repo ini.

Fase 0–6, 8a, dan 9 dari dokumen issue dikerjakan berurutan (satu fase = satu
commit). Fase 7 (verifikasi email) dan Fase 8b (wishlist server-side) sengaja
**tidak** dikerjakan — keduanya diblokir oleh backend (`requireEmailVerification`
belum aktif, endpoint wishlist belum ada) dan issue eksplisit meminta itu jadi
issue terpisah di `khena-backend`, bukan ditambal di sini.

## Yang berubah

- **Fase 0** — `better-auth` dependency, `NEXT_PUBLIC_API_BASE_URL` wajib (bukan optional lagi).
- **Fase 1** — `infrastructure/auth/auth-client.ts` (klien better-auth + plugin `phone`), `error-messages.ts` (pemetaan kode error → pesan user), `withCredentials: true` di `apiClient`.
- **Fase 2** — `AuthProvider` ditulis ulang di atas `authClient.useSession()`, tidak ada lagi state/localStorage sendiri.
- **Fase 3** — `AccountDrawer`: skema Zod diperketat identik backend, field `phone` baru, mode `confirm` dihapus (autoSignIn aktif), link "Forgot password?" dan "View Account".
- **Fase 4** — `<RequireAuth>` (guard UX, bukan keamanan) + halaman `/account`, `/checkout` dibungkus guard.
- **Fase 5** — `/forgot-password` dan `/reset-password` (baca `token`/`error` dari query, `Suspense` boundary untuk `useSearchParams`).
- **Fase 6** — form update profil (nama & telepon) di `/account`, email read-only.
- **Fase 8a** — wishlist dikunci ke `user.id` (UUID asli, bukan email mock), wishlist tamu (`khena.wishlist.guest`) digabung otomatis saat login.
- **Fase 9** — `ApiError` dengan flag `isUnauthorized` (tanpa auto-redirect global), README ditambah bagian "Menjalankan bersama backend" + catatan deployment.
- Perbaikan tambahan yang ditemukan saat implementasi: `WishlistButton` sebelumnya disembunyikan total untuk tamu (peninggalan ISSUE-14) — ini akan membuat fitur wishlist tamu di Fase 8a mustahil dipakai dari UI, jadi guard-nya dihapus. Kode error `USER_ALREADY_EXISTS` yang ditebak di Fase 1 ternyata salah — server sungguhan membalas `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL`, sudah diperbaiki setelah verifikasi manual.

## Verifikasi manual

Dijalankan langsung terhadap `khena-backend` lokal (Postgres + migrasi + `bun run dev`) dan frontend ini via browser — bukan cuma compile check:

- Register (dengan telepon) → langsung login, drawer tertutup, nama tampil.
- Refresh keras & tutup/buka tab → tetap login (sesi dari cookie, bukan localStorage; `khena.auth-user` sudah tidak ada).
- Sign out → kembali ke tamu; `/account` dan `/checkout` menampilkan ajakan sign in tanpa flash konten.
- Login password salah → pesan generic ("Invalid login — check your email and password and try again."), tidak membedakan email tidak ada vs password salah.
- Register email yang sama → "An account with this email already exists."
- Lupa password → link direct terbaca dari log backend (`MAIL_DRIVER=console`) → set password baru → berhasil login dengan password baru.
- `/reset-password` tanpa token / dengan token rusak → pesan error ramah + tautan "request a new link", bukan crash.
- Update nama & telepon di `/account` → tersimpan, tetap ada setelah refresh, tampil ikut berubah di drawer tanpa reload.
- Simpan 2 produk sebagai tamu → login → keduanya muncul di Saved Pieces, key `khena.wishlist.guest` hilang, wishlist tersimpan di key `khena.wishlist.<uuid>`.
- Password lemah (`abc123`, 6 karakter) ditolak di client dengan pesan **identik** dengan backend.
- Validasi telepon salah ditolak di client sebelum request terkirim.

`bun run lint`, `bunx tsc --noEmit`, dan `bun run build` semuanya bersih.

## Di luar scope PR ini (butuh issue terpisah di `khena-backend`)

- Fase 7 — verifikasi email (backend belum punya blok `emailVerification`).
- Fase 8b — endpoint wishlist server-side (`contract.md` belum memuatnya).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
