### PR TITLE
feat(navbar): integrasi API navbar (SHOP & COLLECTION)

### DIFF
--- a/application/use-cases/get-navigation-menu.ts
+++ b/application/use-cases/get-navigation-menu.ts
@@ -1,0 +1,16 @@
+import type {NavigationMenu} from "@/domain/entities/navigation";
+import {navigationRepository} from "@/infrastructure/repositories";
+import {NAVIGATION_FALLBACK} from "@/presentation/lib/navigation-fallback";
+
+/**
+ * Data dropdown navbar. Tidak pernah melempar: navbar ada di root layout, jadi
+ * kegagalan di sini tidak boleh mengubah seluruh situs jadi halaman error.
+ */
+export async function getNavigationMenu(): Promise<NavigationMenu> {
+  try {
+    return await navigationRepository.get();
+  } catch (error) {
+    console.error("[navigation] gagal memuat menu, memakai fallback kosong", error);
+    return NAVIGATION_FALLBACK;
+  }
+}

--- a/domain/entities/featured-product.ts
+++ b/domain/entities/featured-product.ts
@@ -8,6 +8,7 @@
 export type FeaturedProduct = {
   id: string;
   name: string;
+  sku: string;
   image?: string;
   soldOut: boolean;
 };

--- a/domain/entities/navigation.ts
+++ b/domain/entities/navigation.ts
@@ -1,0 +1,29 @@
+/**
+ * Bentuk data yang dibutuhkan navbar. Sengaja terpisah dari `Category` dan
+ * `Collection`: endpoint publik (contract.md Bagian 32 & 34) mengirim field yang
+ * jauh lebih sedikit, dan room type di backend bukan union tetap seperti
+ * `CategoryRoom` — admin bebas membuat room type baru.
+ */
+export type NavCategory = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
+export type NavRoomGroup = {
+  id: string;
+  slug: string;
+  name: string;
+  categories: NavCategory[];
+};
+
+export type NavCollection = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
+export type NavigationMenu = {
+  shopGroups: NavRoomGroup[];
+  collections: NavCollection[];
+};

--- a/domain/entities/product-summary.ts
+++ b/domain/entities/product-summary.ts
@@ -1,0 +1,26 @@
+/**
+ * Bentuk ringkas produk untuk listing publik (`productSummary`, contract.md
+ * Bagian 30) — dipakai fitur search. Sengaja terpisah dari `Product`:
+ * endpoint publik hanya mewakili **varian pertama** (bukan termurah/
+ * terpopuler) dan tidak membawa slug kategori/koleksi, deskripsi, dimensi,
+ * dsb. Memaksakan `Product` di sini berarti mengarang field yang tidak ada.
+ */
+export type ProductSummary = {
+  id: string;
+  name: string;
+  sku: string;
+  /** URL gambar varian pertama, atau `undefined` bila belum ada. */
+  image?: string;
+  price: number;
+  discountPercent: number;
+  priceAfterDiscount: number;
+  stock: number;
+};
+
+export function isProductSummarySoldOut(p: ProductSummary): boolean {
+  return p.stock <= 0;
+}
+
+export function isProductSummaryOnSale(p: ProductSummary): boolean {
+  return p.discountPercent > 0 && p.priceAfterDiscount < p.price;
+}

--- a/domain/repositories/navigation-repository.ts
+++ b/domain/repositories/navigation-repository.ts
@@ -1,0 +1,5 @@
+import type {NavigationMenu} from "@/domain/entities/navigation";
+
+export interface NavigationRepository {
+  get(): Promise<NavigationMenu>;
+}

--- a/domain/repositories/product-search-repository.ts
+++ b/domain/repositories/product-search-repository.ts
@@ -1,0 +1,10 @@
+import type {ProductSummary} from "@/domain/entities/product-summary";
+
+export interface ProductSearchRepository {
+  /**
+   * `signal` opsional: dipakai pemanggil client (mis. TanStack Query) untuk
+   * membatalkan request yang sudah usang saat user mengetik lebih cepat dari
+   * jawaban server.
+   */
+  search(query: string, signal?: AbortSignal): Promise<ProductSummary[]>;
+}

--- a/infrastructure/api/endpoints.ts
+++ b/infrastructure/api/endpoints.ts
@@ -7,4 +7,14 @@ export const API_ENDPOINTS = {
   products: {
     detail: (id: string) => `/products/${id}`,
   },
+  // Room type + kategori published, dua level sekaligus — contract.md Bagian 32.
+  // BUKAN "/admin/categories" (Bagian 9, bentuk datanya berbeda) dan BUKAN
+  // "/admin/room-types" (Bagian 8, endpoint admin).
+  categories: {
+    list: "/categories",
+  },
+  // contract.md Bagian 34. BUKAN "/admin/collections".
+  collections: {
+    list: "/collections",
+  },
 } as const;

--- a/infrastructure/api/endpoints.ts
+++ b/infrastructure/api/endpoints.ts
@@ -5,6 +5,8 @@ export const API_ENDPOINTS = {
     list: "/pages",
   },
   products: {
+    // contract.md Bagian 33 — dipakai fitur search (query `search`).
+    list: "/products",
     detail: (id: string) => `/products/${id}`,
   },
   // Room type + kategori published, dua level sekaligus — contract.md Bagian 32.

--- a/infrastructure/api/mappers/featured-product.ts
+++ b/infrastructure/api/mappers/featured-product.ts
@@ -6,6 +6,7 @@ export function toFeaturedProduct(product: ProductDetail): FeaturedProduct {
   return {
     id: product.id,
     name: product.name,
+    sku: product.sku,
     image: firstVariant?.image ?? product.media[0] ?? undefined,
     soldOut: (firstVariant?.stock ?? 0) <= 0,
   };

--- a/infrastructure/api/mappers/navigation.ts
+++ b/infrastructure/api/mappers/navigation.ts
@@ -1,0 +1,27 @@
+import type {NavCollection, NavRoomGroup} from "@/domain/entities/navigation";
+import {navCollectionsSchema, navRoomGroupsSchema} from "@/infrastructure/api/schemas/navigation";
+
+/**
+ * Room type dengan `categories: []` sengaja dibuang (keputusan D2 issue navbar):
+ * kolom kosong di dropdown lebih membingungkan daripada kolom yang tidak ada.
+ */
+export function toNavRoomGroups(raw: unknown): NavRoomGroup[] {
+  return navRoomGroupsSchema
+    .parse(raw)
+    .filter((row) => row !== null)
+    .map((row) => ({
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      // Urutan kategori sudah diatur backend (`order` lalu nama) — jangan di-sort ulang.
+      categories: row.categories.map((c) => ({id: c.id, slug: c.slug, name: c.name})),
+    }))
+    .filter((group) => group.categories.length > 0);
+}
+
+export function toNavCollections(raw: unknown): NavCollection[] {
+  return navCollectionsSchema
+    .parse(raw)
+    .filter((row) => row !== null)
+    .map((row) => ({id: row.id, slug: row.slug, name: row.name}));
+}

--- a/infrastructure/api/mappers/product-summary.ts
+++ b/infrastructure/api/mappers/product-summary.ts
@@ -1,0 +1,18 @@
+import type {ProductSummary} from "@/domain/entities/product-summary";
+import {productSummariesSchema} from "@/infrastructure/api/schemas/product-summary";
+
+export function toProductSummaries(raw: unknown): ProductSummary[] {
+  return productSummariesSchema
+    .parse(raw)
+    .filter((row) => row !== null)
+    .map((row) => ({
+      id: row.id,
+      name: row.name,
+      sku: row.sku,
+      image: row.image ?? undefined,
+      price: row.price,
+      discountPercent: row.discountPercent,
+      priceAfterDiscount: row.priceAfterDiscount,
+      stock: row.stock,
+    }));
+}

--- a/infrastructure/api/schemas/navigation.ts
+++ b/infrastructure/api/schemas/navigation.ts
@@ -1,0 +1,37 @@
+import {z} from "zod";
+
+/** Satu kategori di dalam room type — contract.md Bagian 32. */
+const navCategorySchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+});
+
+/** Satu room type beserta kategorinya. */
+const navRoomGroupSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+  // Room type tanpa kategori published tetap dikirim backend dengan array kosong.
+  categories: z.array(navCategorySchema).catch([]),
+});
+
+/**
+ * `.nullable().catch(null)` per item: satu baris yang bentuknya rusak jadi `null`
+ * lalu dibuang di mapper, sisanya tetap tampil. `.catch([])` di level array adalah
+ * jaring terakhir kalau `data` ternyata bukan array sama sekali.
+ */
+export const navRoomGroupsSchema = z
+  .array(navRoomGroupSchema.nullable().catch(null))
+  .catch([]);
+
+/** Satu koleksi — contract.md Bagian 34. Field gambar & statistik tidak dipakai navbar. */
+const navCollectionSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+});
+
+export const navCollectionsSchema = z
+  .array(navCollectionSchema.nullable().catch(null))
+  .catch([]);

--- a/infrastructure/api/schemas/product-summary.ts
+++ b/infrastructure/api/schemas/product-summary.ts
@@ -1,0 +1,22 @@
+import {z} from "zod";
+
+/**
+ * `productSummary` — contract.md Bagian 30 (dipakai `GET /api/products`,
+ * dsb). `.nullable().catch(null)` per item: satu baris yang bentuknya rusak
+ * jadi `null` lalu dibuang di mapper, sisanya tetap tampil. `.catch([])` di
+ * level array adalah jaring terakhir kalau `data` ternyata bukan array.
+ */
+const productSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  sku: z.string(),
+  image: z.string().nullable().catch(null),
+  price: z.number(),
+  discountPercent: z.number(),
+  priceAfterDiscount: z.number(),
+  stock: z.number(),
+});
+
+export const productSummariesSchema = z
+  .array(productSummarySchema.nullable().catch(null))
+  .catch([]);

--- a/infrastructure/api/schemas/product.ts
+++ b/infrastructure/api/schemas/product.ts
@@ -14,6 +14,7 @@ export const productVariantSchema = z.object({
 export const productDetailSchema = z.object({
   id: z.string(),
   name: z.string(),
+  sku: z.string(),
   media: z.array(z.string()).optional().default([]),
   variants: z.array(productVariantSchema).optional().default([]),
 });

--- a/infrastructure/repositories/client.ts
+++ b/infrastructure/repositories/client.ts
@@ -1,0 +1,14 @@
+import type {ProductSearchRepository} from "@/domain/repositories/product-search-repository";
+import {HttpProductSearchRepository} from "@/infrastructure/repositories/http-product-search-repository";
+
+/**
+ * Barrel TERPISAH dari `infrastructure/repositories/index.ts` — barrel utama
+ * itu mengimpor repository yang lewat `serverFetch.ts` (`import "server-only"`)
+ * secara statis, jadi mengimpor apa pun darinya dari komponen `"use client"`
+ * ikut menarik kode server-only ke bundle browser dan build gagal.
+ *
+ * Isi berkas ini khusus repository yang aman & memang dipanggil langsung dari
+ * client (transport `apiClient`, bukan `serverFetch`) — saat ini hanya
+ * `productSearchRepository` untuk fitur search product.
+ */
+export const productSearchRepository: ProductSearchRepository = new HttpProductSearchRepository();

--- a/infrastructure/repositories/http-navigation-repository.ts
+++ b/infrastructure/repositories/http-navigation-repository.ts
@@ -1,0 +1,52 @@
+import type {NavigationRepository} from "@/domain/repositories/navigation-repository";
+import type {NavCollection, NavRoomGroup, NavigationMenu} from "@/domain/entities/navigation";
+import {API_ENDPOINTS} from "@/infrastructure/api/endpoints";
+import {serverFetch} from "@/infrastructure/api/server-fetch";
+import {toNavCollections, toNavRoomGroups} from "@/infrastructure/api/mappers/navigation";
+
+/** Dropdown SHOP menampilkan 3 room teratas — paginasi endpoint ini per room type. */
+const ROOM_LIMIT = 3;
+/** Sama dengan default backend; membatasi agar baris koleksi di dropdown tidak meluber. */
+const COLLECTION_LIMIT = 10;
+
+const REVALIDATE_SECONDS = 300;
+
+export class HttpNavigationRepository implements NavigationRepository {
+  async get(): Promise<NavigationMenu> {
+    // Dua sumber ditangani terpisah: kalau /collections mati, dropdown SHOP tetap
+    // punya isi (dan sebaliknya).
+    const [shopGroups, collections] = await Promise.all([
+      this.getShopGroups(),
+      this.getCollections(),
+    ]);
+    return {shopGroups, collections};
+  }
+
+  private async getShopGroups(): Promise<NavRoomGroup[]> {
+    try {
+      const raw = await serverFetch<unknown>(API_ENDPOINTS.categories.list, {
+        query: {page: 1, limit: ROOM_LIMIT},
+        revalidateSeconds: REVALIDATE_SECONDS,
+        tags: ["navigation", "categories"],
+      });
+      return toNavRoomGroups(raw);
+    } catch (error) {
+      console.error("[navigation] gagal memuat kategori, dropdown SHOP dikosongkan", error);
+      return [];
+    }
+  }
+
+  private async getCollections(): Promise<NavCollection[]> {
+    try {
+      const raw = await serverFetch<unknown>(API_ENDPOINTS.collections.list, {
+        query: {page: 1, limit: COLLECTION_LIMIT},
+        revalidateSeconds: REVALIDATE_SECONDS,
+        tags: ["navigation", "collections"],
+      });
+      return toNavCollections(raw);
+    } catch (error) {
+      console.error("[navigation] gagal memuat koleksi, dropdown COLLECTION dikosongkan", error);
+      return [];
+    }
+  }
+}

--- a/infrastructure/repositories/http-product-search-repository.ts
+++ b/infrastructure/repositories/http-product-search-repository.ts
@@ -1,0 +1,30 @@
+import type {ProductSearchRepository} from "@/domain/repositories/product-search-repository";
+import type {ProductSummary} from "@/domain/entities/product-summary";
+import {API_ENDPOINTS} from "@/infrastructure/api/endpoints";
+import {apiClient} from "@/infrastructure/api/client";
+import {toProductSummaries} from "@/infrastructure/api/mappers/product-summary";
+
+/** Hasil ditampilkan di overlay pencarian, bukan halaman katalog — cukup segenggam. */
+const RESULT_LIMIT = 6;
+
+/**
+ * Beda dari repository lain di folder ini (`Http*` untuk navbar, landing,
+ * dsb): itu semua dipanggil dari Server Component lewat `serverFetch`
+ * (konten yang bisa di-cache/`revalidate`). Pencarian-saat-mengetik murni
+ * interaksi browser — tidak ada render server untuk dihidrasi, jadi transport-
+ * nya `apiClient` (axios), sama seperti endpoint bersesi lain. Dipanggil
+ * langsung dari komponen `"use client"` (`SearchOverlay`), bukan lewat
+ * Server Component + props seperti data navbar.
+ */
+export class HttpProductSearchRepository implements ProductSearchRepository {
+  async search(query: string, signal?: AbortSignal): Promise<ProductSummary[]> {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    const res = await apiClient.get(API_ENDPOINTS.products.list, {
+      params: {search: trimmed, limit: RESULT_LIMIT},
+      signal,
+    });
+    return toProductSummaries(res.data.data);
+  }
+}

--- a/infrastructure/repositories/index.ts
+++ b/infrastructure/repositories/index.ts
@@ -47,3 +47,9 @@ export const infoContentRepository: InfoContentRepository = new HttpInfoContentR
 // categoryRepository/collectionRepository di atas: /shop, /categories, /collections,
 // dan /product/[id] masih memakai mock dan akan dimigrasikan di issue terpisah.
 export const navigationRepository: NavigationRepository = new HttpNavigationRepository();
+
+// `productSearchRepository` (fitur search product) SENGAJA TIDAK ada di sini.
+// Berkas ini mengimpor http-navigation-repository.ts -> server-fetch.ts, yang
+// `import "server-only"` — mengimpor apa pun dari barrel ini di komponen
+// "use client" (search-overlay.tsx) menarik kode server-only itu ke bundle
+// browser dan build gagal. Lihat infrastructure/repositories/client.ts.

--- a/infrastructure/repositories/index.ts
+++ b/infrastructure/repositories/index.ts
@@ -6,6 +6,7 @@ import type {SiteSettingsRepository} from "@/domain/repositories/site-settings-r
 import type {LandingContentRepository} from "@/domain/repositories/landing-content-repository";
 import type {FeaturedProductRepository} from "@/domain/repositories/featured-product-repository";
 import type {InfoContentRepository} from "@/domain/repositories/info-content-repository";
+import type {NavigationRepository} from "@/domain/repositories/navigation-repository";
 import {MockCategoryRepository} from "@/infrastructure/mock/repositories/mock-category-repository";
 import {MockCollectionRepository} from "@/infrastructure/mock/repositories/mock-collection-repository";
 import {MockJobRepository} from "@/infrastructure/mock/repositories/mock-job-repository";
@@ -14,6 +15,7 @@ import {MockSiteSettingsRepository} from "@/infrastructure/mock/repositories/moc
 import {HttpLandingContentRepository} from "@/infrastructure/repositories/http-landing-content-repository";
 import {HttpFeaturedProductRepository} from "@/infrastructure/repositories/http-featured-product-repository";
 import {HttpInfoContentRepository} from "@/infrastructure/repositories/http-info-content-repository";
+import {HttpNavigationRepository} from "@/infrastructure/repositories/http-navigation-repository";
 
 // Satu-satunya berkas yang berubah saat backend REST siap (ISSUE-15) — bagian
 // 2.2 issue.md. Tukar implementasi mock dengan implementasi Http* di sini,
@@ -40,3 +42,8 @@ export const landingContentRepository: LandingContentRepository = new HttpLandin
 export const featuredProductRepository: FeaturedProductRepository = new HttpFeaturedProductRepository();
 
 export const infoContentRepository: InfoContentRepository = new HttpInfoContentRepository();
+
+// Navigasi navbar (issue ini) — sudah lewat backend REST. Sengaja TIDAK menukar
+// categoryRepository/collectionRepository di atas: /shop, /categories, /collections,
+// dan /product/[id] masih memakai mock dan akan dimigrasikan di issue terpisah.
+export const navigationRepository: NavigationRepository = new HttpNavigationRepository();

--- a/presentation/components/layout/global-overlays.tsx
+++ b/presentation/components/layout/global-overlays.tsx
@@ -2,7 +2,7 @@ import {MobileMenu} from "@/presentation/components/layout/mobile-menu";
 import {SearchOverlay} from "@/presentation/components/search/search-overlay";
 import {CartDrawer} from "@/presentation/components/cart/cart-drawer";
 import {AccountDrawer} from "@/presentation/components/account/account-drawer";
-import type {ShopMenuGroup} from "@/presentation/components/layout/nav-data";
+import type {NavCollection, NavRoomGroup} from "@/domain/entities/navigation";
 import type {Category} from "@/domain/entities/category";
 import type {Collection} from "@/domain/entities/collection";
 import type {Product} from "@/domain/entities/product";
@@ -13,18 +13,23 @@ export function GlobalOverlays({
   categories,
   collections,
   shopGroups,
+  navCollections,
 }: {
   products: Product[];
   categories: Category[];
+  // Entity mock — dipakai untuk `collectionNameBySlug` milik SearchOverlay, yang
+  // belum dimigrasikan (di luar lingkup issue navbar). Bukan duplikasi yang
+  // tidak disengaja dengan `navCollections` di bawah, yang datanya dari API.
   collections: Collection[];
-  shopGroups: ShopMenuGroup[];
+  shopGroups: NavRoomGroup[];
+  navCollections: NavCollection[];
 }) {
   const categoryNameBySlug = Object.fromEntries(categories.map((c) => [c.slug, c.name]));
   const collectionNameBySlug = Object.fromEntries(collections.map((c) => [c.slug, c.name]));
 
   return (
     <>
-      <MobileMenu shopGroups={shopGroups} collections={collections} />
+      <MobileMenu shopGroups={shopGroups} collections={navCollections} />
       <SearchOverlay
         products={products}
         categoryNameBySlug={categoryNameBySlug}

--- a/presentation/components/layout/global-overlays.tsx
+++ b/presentation/components/layout/global-overlays.tsx
@@ -3,38 +3,25 @@ import {SearchOverlay} from "@/presentation/components/search/search-overlay";
 import {CartDrawer} from "@/presentation/components/cart/cart-drawer";
 import {AccountDrawer} from "@/presentation/components/account/account-drawer";
 import type {NavCollection, NavRoomGroup} from "@/domain/entities/navigation";
-import type {Category} from "@/domain/entities/category";
-import type {Collection} from "@/domain/entities/collection";
-import type {Product} from "@/domain/entities/product";
 
-/** Overlay global yang dipasang sekali di root layout — mobile menu & search. */
+/**
+ * Overlay global yang dipasang sekali di root layout — mobile menu & search.
+ * `SearchOverlay` tidak lagi menerima produk/kategori/koleksi lewat props
+ * (bagian fitur search product): ia mengambil hasil pencariannya sendiri
+ * dari API lewat `apiClient`, bukan dari data yang di-fetch Server Component
+ * di sini.
+ */
 export function GlobalOverlays({
-  products,
-  categories,
-  collections,
   shopGroups,
   navCollections,
 }: {
-  products: Product[];
-  categories: Category[];
-  // Entity mock — dipakai untuk `collectionNameBySlug` milik SearchOverlay, yang
-  // belum dimigrasikan (di luar lingkup issue navbar). Bukan duplikasi yang
-  // tidak disengaja dengan `navCollections` di bawah, yang datanya dari API.
-  collections: Collection[];
   shopGroups: NavRoomGroup[];
   navCollections: NavCollection[];
 }) {
-  const categoryNameBySlug = Object.fromEntries(categories.map((c) => [c.slug, c.name]));
-  const collectionNameBySlug = Object.fromEntries(collections.map((c) => [c.slug, c.name]));
-
   return (
     <>
       <MobileMenu shopGroups={shopGroups} collections={navCollections} />
-      <SearchOverlay
-        products={products}
-        categoryNameBySlug={categoryNameBySlug}
-        collectionNameBySlug={collectionNameBySlug}
-      />
+      <SearchOverlay />
       <CartDrawer />
       <AccountDrawer />
     </>

--- a/presentation/components/layout/mega-menu.tsx
+++ b/presentation/components/layout/mega-menu.tsx
@@ -6,8 +6,7 @@ import Link from "next/link";
 import {cn} from "@/presentation/lib/cn";
 import {Container} from "@/presentation/components/ui/container";
 import {TextLink} from "@/presentation/components/ui/text-link";
-import type {Collection} from "@/domain/entities/collection";
-import type {ShopMenuGroup} from "@/presentation/components/layout/nav-data";
+import type {NavCollection, NavRoomGroup} from "@/domain/entities/navigation";
 
 const CLOSE_DELAY_MS = 160;
 
@@ -18,8 +17,8 @@ type SharedProps = {
 };
 
 export type MegaMenuProps =
-  | (SharedProps & {variant: "shop"; shopGroups: ShopMenuGroup[]})
-  | (SharedProps & {variant: "collection"; collections: Collection[]});
+  | (SharedProps & {variant: "shop"; shopGroups: NavRoomGroup[]})
+  | (SharedProps & {variant: "collection"; collections: NavCollection[]});
 
 /**
  * Trigger + dropdown untuk SHOP/COLLECTION di navbar — bagian 3.1 issue.md.
@@ -125,8 +124,8 @@ export function MegaMenu(props: MegaMenuProps) {
             {props.variant === "shop" ? (
               <div className="grid grid-cols-3 gap-10">
                 {props.shopGroups.map((group) => (
-                  <div key={group.room}>
-                    <p className="mb-4 text-xs uppercase tracking-label text-muted">{group.label}</p>
+                  <div key={group.slug}>
+                    <p className="mb-4 text-xs uppercase tracking-label text-muted">{group.name}</p>
                     <ul className="space-y-2">
                       {group.categories.map((category) => (
                         <li key={category.id}>

--- a/presentation/components/layout/mobile-menu.tsx
+++ b/presentation/components/layout/mobile-menu.tsx
@@ -9,17 +9,17 @@ import {TextLink} from "@/presentation/components/ui/text-link";
 import {Icon} from "@/presentation/components/icon";
 import {ICONS} from "@/presentation/components/icons";
 import {cn} from "@/presentation/lib/cn";
-import {NAV_LINKS, type ShopMenuGroup} from "@/presentation/components/layout/nav-data";
+import {NAV_LINKS} from "@/presentation/components/layout/nav-data";
 import {useUi} from "@/presentation/providers/ui-provider";
-import type {Collection} from "@/domain/entities/collection";
+import type {NavCollection, NavRoomGroup} from "@/domain/entities/navigation";
 
 /** Overlay full-screen di bawah `lg:` (termasuk tablet) — bagian 3.1 issue.md. */
 export function MobileMenu({
   shopGroups,
   collections,
 }: {
-  shopGroups: ShopMenuGroup[];
-  collections: Collection[];
+  shopGroups: NavRoomGroup[];
+  collections: NavCollection[];
 }) {
   const {isOpen, close} = useUi();
   const open = isOpen("mobileMenu");
@@ -41,13 +41,13 @@ export function MobileMenu({
       </div>
       <nav className="flex flex-col px-6 py-10">
         {NAV_LINKS.map((link) => {
-          if (link.label === "SHOP") {
+          if (link.label === "SHOP" && shopGroups.length > 0) {
             return (
               <NavAccordion key={link.href} title={link.label}>
                 <div className="flex flex-col gap-6">
                   {shopGroups.map((group) => (
-                    <div key={group.room}>
-                      <p className="mb-3 text-xs uppercase tracking-label text-muted">{group.label}</p>
+                    <div key={group.slug}>
+                      <p className="mb-3 text-xs uppercase tracking-label text-muted">{group.name}</p>
                       <ul className="space-y-3">
                         {group.categories.map((category) => (
                           <li key={category.id}>
@@ -65,7 +65,7 @@ export function MobileMenu({
             );
           }
 
-          if (link.label === "COLLECTION") {
+          if (link.label === "COLLECTION" && collections.length > 0) {
             return (
               <NavAccordion key={link.href} title={link.label}>
                 <div className="flex flex-col gap-3">

--- a/presentation/components/layout/nav-data.ts
+++ b/presentation/components/layout/nav-data.ts
@@ -1,6 +1,3 @@
-import type {Category, CategoryRoom} from "@/domain/entities/category";
-import type {Product} from "@/domain/entities/product";
-
 export const NAV_LINKS = [
   {label: "SHOP", href: "/shop"},
   {label: "COLLECTION", href: "/collections"},
@@ -8,37 +5,3 @@ export const NAV_LINKS = [
   {label: "SHOWROOM", href: "/showroom"},
   {label: "ABOUT US", href: "/about"},
 ] as const;
-
-const ROOM_ORDER: CategoryRoom[] = ["living-room", "dining-room", "bed-room"];
-
-const ROOM_LABELS: Record<CategoryRoom, string> = {
-  "living-room": "Living Room",
-  "dining-room": "Dining Room",
-  "bed-room": "Bed Room",
-};
-
-export type ShopMenuGroup = {
-  room: CategoryRoom;
-  label: string;
-  categories: Category[];
-};
-
-/**
- * Kelompokkan kategori per ruangan untuk mega dropdown SHOP — bagian 3.1
- * issue.md. Hanya menyertakan grup yang punya minimal satu kategori dengan
- * produk live.
- */
-export function buildShopMenuGroups(
-  categories: Category[],
-  liveProducts: Product[]
-): ShopMenuGroup[] {
-  const categoriesWithLiveProducts = new Set(liveProducts.map((p) => p.category));
-
-  return ROOM_ORDER.map((room) => ({
-    room,
-    label: ROOM_LABELS[room],
-    categories: categories.filter(
-      (category) => category.room === room && categoriesWithLiveProducts.has(category.slug)
-    ),
-  })).filter((group) => group.categories.length > 0);
-}

--- a/presentation/components/layout/nav-links.tsx
+++ b/presentation/components/layout/nav-links.tsx
@@ -3,16 +3,16 @@
 import Link from "next/link";
 import {usePathname} from "next/navigation";
 import {cn} from "@/presentation/lib/cn";
-import {NAV_LINKS, type ShopMenuGroup} from "@/presentation/components/layout/nav-data";
+import {NAV_LINKS} from "@/presentation/components/layout/nav-data";
 import {MegaMenu} from "@/presentation/components/layout/mega-menu";
-import type {Collection} from "@/domain/entities/collection";
+import type {NavCollection, NavRoomGroup} from "@/domain/entities/navigation";
 
 export function NavLinks({
   shopGroups,
   collections,
 }: {
-  shopGroups: ShopMenuGroup[];
-  collections: Collection[];
+  shopGroups: NavRoomGroup[];
+  collections: NavCollection[];
 }) {
   const pathname = usePathname();
 
@@ -21,7 +21,7 @@ export function NavLinks({
       {NAV_LINKS.map((link) => {
         const isActive = pathname === link.href || pathname.startsWith(`${link.href}/`);
 
-        if (link.label === "SHOP") {
+        if (link.label === "SHOP" && shopGroups.length > 0) {
           return (
             <MegaMenu
               key={link.href}
@@ -34,7 +34,7 @@ export function NavLinks({
           );
         }
 
-        if (link.label === "COLLECTION") {
+        if (link.label === "COLLECTION" && collections.length > 0) {
           return (
             <MegaMenu
               key={link.href}

--- a/presentation/components/layout/navbar.tsx
+++ b/presentation/components/layout/navbar.tsx
@@ -1,16 +1,15 @@
 import Link from "next/link";
 import {NavLinks} from "@/presentation/components/layout/nav-links";
 import {NavbarActions} from "@/presentation/components/layout/navbar-actions";
-import type {ShopMenuGroup} from "@/presentation/components/layout/nav-data";
-import type {Collection} from "@/domain/entities/collection";
+import type {NavCollection, NavRoomGroup} from "@/domain/entities/navigation";
 
 /** Navbar sticky 80px dengan mega dropdown — bagian 3.1 issue.md. */
 export function Navbar({
   shopGroups,
   collections,
 }: {
-  shopGroups: ShopMenuGroup[];
-  collections: Collection[];
+  shopGroups: NavRoomGroup[];
+  collections: NavCollection[];
 }) {
   return (
     <header className="sticky top-0 z-60 border-b border-ink bg-cream">

--- a/presentation/components/layout/site-chrome.tsx
+++ b/presentation/components/layout/site-chrome.tsx
@@ -1,39 +1,25 @@
 import type {ReactNode} from "react";
 import {getNavigationMenu} from "@/application/use-cases/get-navigation-menu";
-import {getPublishedCategories} from "@/application/use-cases/get-published-categories";
-import {getVisibleCollections} from "@/application/use-cases/get-visible-collections";
-import {getLiveProducts} from "@/application/use-cases/get-live-products";
 import {Navbar} from "@/presentation/components/layout/navbar";
 import {Footer} from "@/presentation/components/layout/footer";
 import {GlobalOverlays} from "@/presentation/components/layout/global-overlays";
 
 /**
  * Kerangka situs (navbar, footer, overlay global) dipasang sekali di root
- * layout. Data kategori/koleksi/produk diambil satu kali di sini lalu
- * diteruskan sebagai props ke Navbar & GlobalOverlays.
+ * layout. Sebelum fitur search product, berkas ini juga mengambil
+ * categories/collections/products mock hanya untuk diteruskan ke
+ * `SearchOverlay`; sekarang `SearchOverlay` mengambil hasil pencariannya
+ * sendiri lewat API, jadi fetch itu dihapus dari sini.
  */
 export async function SiteChrome({children}: {children: ReactNode}) {
-  // `categories`, `collections`, dan `products` di bawah masih dari mock — dipakai
-  // SearchOverlay, yang belum dimigrasikan (di luar lingkup issue navbar).
-  const [navigation, categories, collections, products] = await Promise.all([
-    getNavigationMenu(),
-    getPublishedCategories(),
-    getVisibleCollections(),
-    getLiveProducts(),
-  ]);
+  const navigation = await getNavigationMenu();
 
   return (
     <>
       <Navbar shopGroups={navigation.shopGroups} collections={navigation.collections} />
       {children}
       <Footer />
-      <GlobalOverlays
-        products={products}
-        categories={categories}
-        collections={collections}
-        shopGroups={navigation.shopGroups}
-        navCollections={navigation.collections}
-      />
+      <GlobalOverlays shopGroups={navigation.shopGroups} navCollections={navigation.collections} />
     </>
   );
 }

--- a/presentation/components/layout/site-chrome.tsx
+++ b/presentation/components/layout/site-chrome.tsx
@@ -1,11 +1,11 @@
 import type {ReactNode} from "react";
+import {getNavigationMenu} from "@/application/use-cases/get-navigation-menu";
 import {getPublishedCategories} from "@/application/use-cases/get-published-categories";
 import {getVisibleCollections} from "@/application/use-cases/get-visible-collections";
 import {getLiveProducts} from "@/application/use-cases/get-live-products";
 import {Navbar} from "@/presentation/components/layout/navbar";
 import {Footer} from "@/presentation/components/layout/footer";
 import {GlobalOverlays} from "@/presentation/components/layout/global-overlays";
-import {buildShopMenuGroups} from "@/presentation/components/layout/nav-data";
 
 /**
  * Kerangka situs (navbar, footer, overlay global) dipasang sekali di root
@@ -13,24 +13,26 @@ import {buildShopMenuGroups} from "@/presentation/components/layout/nav-data";
  * diteruskan sebagai props ke Navbar & GlobalOverlays.
  */
 export async function SiteChrome({children}: {children: ReactNode}) {
-  const [categories, collections, products] = await Promise.all([
+  // `categories`, `collections`, dan `products` di bawah masih dari mock — dipakai
+  // SearchOverlay, yang belum dimigrasikan (di luar lingkup issue navbar).
+  const [navigation, categories, collections, products] = await Promise.all([
+    getNavigationMenu(),
     getPublishedCategories(),
     getVisibleCollections(),
     getLiveProducts(),
   ]);
 
-  const shopGroups = buildShopMenuGroups(categories, products);
-
   return (
     <>
-      <Navbar shopGroups={shopGroups} collections={collections} />
+      <Navbar shopGroups={navigation.shopGroups} collections={navigation.collections} />
       {children}
       <Footer />
       <GlobalOverlays
         products={products}
         categories={categories}
         collections={collections}
-        shopGroups={shopGroups}
+        shopGroups={navigation.shopGroups}
+        navCollections={navigation.collections}
       />
     </>
   );

--- a/presentation/components/product/featured-product-card.tsx
+++ b/presentation/components/product/featured-product-card.tsx
@@ -18,7 +18,7 @@ export type FeaturedProductCardProps = {
  */
 export function FeaturedProductCard({product, className}: FeaturedProductCardProps) {
   return (
-    <Link href={`/product/${product.id}`} className={cn("block", className)}>
+    <Link href={`/product/${product.sku}`} className={cn("block", className)}>
       <Tile className="aspect-[383/384] bg-warm">
         <div className="absolute inset-10 flex items-center justify-center">
           <RemoteImage

--- a/presentation/components/search/search-overlay.tsx
+++ b/presentation/components/search/search-overlay.tsx
@@ -2,8 +2,7 @@
 
 import {useEffect, useRef, useState} from "react";
 import Link from "next/link";
-import {useQuery, keepPreviousData} from "@tanstack/react-query";
-import {Chip} from "@/presentation/components/ui/chip";
+import {keepPreviousData, useQuery} from "@tanstack/react-query";
 import {RemoteImage} from "@/presentation/components/ui/remote-image";
 import {Icon} from "@/presentation/components/icon";
 import {ICONS} from "@/presentation/components/icons";
@@ -12,7 +11,6 @@ import {productSearchRepository} from "@/infrastructure/repositories/client";
 import {isProductSummaryOnSale, isProductSummarySoldOut} from "@/domain/entities/product-summary";
 import {formatIDR} from "@/presentation/lib/format";
 
-const POPULAR_TERMS = ["Sofa", "Lounge Chair", "Dining Table", "Solana Lounge Chair"];
 const AUTOFOCUS_DELAY_MS = 320;
 /** User berhenti mengetik selama ini sebelum request dikirim — bagian fitur search product. */
 const DEBOUNCE_MS = 300;
@@ -111,7 +109,7 @@ export function SearchOverlay() {
             <Icon icon={ICONS.search} className="size-5 text-muted" />
             <input
               ref={inputRef}
-              type="search"
+              type="text"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search pieces..."
@@ -123,20 +121,7 @@ export function SearchOverlay() {
           </div>
 
           <div className="mt-8">
-            {!hasQuery ? (
-              <div className="flex flex-wrap items-baseline gap-6">
-                {/* `items-baseline` (bukan `items-center`) supaya teks "Popular"
-                    sejajar dengan teks Chip — Chip punya `pb-1 border-b-2`
-                    ekstra di bawah yang bikin box-nya lebih tinggi, jadi
-                    `items-center` menggeser baseline teksnya. */}
-                <span className="text-xs uppercase tracking-label text-muted">Popular</span>
-                {POPULAR_TERMS.map((term) => (
-                  <Chip key={term} onClick={() => setQuery(term)}>
-                    {term}
-                  </Chip>
-                ))}
-              </div>
-            ) : isError ? (
+            {!hasQuery ? null : isError ? (
               <p className="text-sm text-muted">Search is unavailable right now. Try again shortly.</p>
             ) : results && results.length > 0 ? (
               <ul className="divide-y divide-hairline">

--- a/presentation/components/search/search-overlay.tsx
+++ b/presentation/components/search/search-overlay.tsx
@@ -1,38 +1,52 @@
 "use client";
 
-import {useEffect, useMemo, useRef, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import Link from "next/link";
+import {useQuery, keepPreviousData} from "@tanstack/react-query";
 import {Chip} from "@/presentation/components/ui/chip";
-import {PlaceholderImage} from "@/presentation/components/ui/placeholder-image";
+import {RemoteImage} from "@/presentation/components/ui/remote-image";
 import {Icon} from "@/presentation/components/icon";
 import {ICONS} from "@/presentation/components/icons";
 import {useUi} from "@/presentation/providers/ui-provider";
-import type {Product} from "@/domain/entities/product";
+import {productSearchRepository} from "@/infrastructure/repositories/client";
+import {isProductSummaryOnSale, isProductSummarySoldOut} from "@/domain/entities/product-summary";
+import {formatIDR} from "@/presentation/lib/format";
 
 const POPULAR_TERMS = ["Sofa", "Lounge Chair", "Dining Table", "Solana Lounge Chair"];
-const MAX_RESULTS = 6;
 const AUTOFOCUS_DELAY_MS = 320;
+/** User berhenti mengetik selama ini sebelum request dikirim — bagian fitur search product. */
+const DEBOUNCE_MS = 300;
 
-export type SearchOverlayProps = {
-  products: Product[];
-  categoryNameBySlug: Record<string, string>;
-  collectionNameBySlug: Record<string, string>;
-};
-
-/** Sheet pencarian turun dari atas — bagian 3.5 issue.md. */
-export function SearchOverlay({
-  products,
-  categoryNameBySlug,
-  collectionNameBySlug,
-}: SearchOverlayProps) {
+/**
+ * Sheet pencarian turun dari atas — bagian 3.5 issue.md, disambungkan ke
+ * `GET /api/products?search=` (contract.md Bagian 33 — fitur search
+ * product). Sengaja tidak lagi menerima daftar produk lewat props seperti
+ * sebelumnya: pencarian-saat-mengetik adalah interaksi browser murni, jadi
+ * repository-nya dipanggil langsung dari sini lewat `apiClient`
+ * (`HttpProductSearchRepository`), bukan lewat props dari Server Component.
+ *
+ * `productSummary` (bentuk hasil API, lihat `domain/entities/product-summary.ts`)
+ * tidak membawa slug kategori/koleksi seperti entity `Product` mock — jadi
+ * subtitle di bawah nama produk sekarang menampilkan harga, bukan
+ * "Kategori · Koleksi" seperti versi mock.
+ *
+ * Konsekuensi yang diterima (sama pola dengan issue navbar #29 soal /shop):
+ * `/product/[id]` masih 100% mock, sedangkan id hasil pencarian ini adalah
+ * UUID asli dari backend — klik hasil pencarian kemungkinan besar mengarah
+ * ke halaman produk kosong sampai `/product/[id]` ikut dimigrasikan di issue
+ * terpisah.
+ */
+export function SearchOverlay() {
   const {isOpen, close} = useUi();
   const open = isOpen("search");
   const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
   function handleClose() {
     close();
     setQuery("");
+    setDebouncedQuery("");
   }
 
   useEffect(() => {
@@ -45,34 +59,37 @@ export function SearchOverlay({
     if (!open) return;
 
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        close();
-        setQuery("");
-      }
+      if (event.key === "Escape") handleClose();
     }
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open, close]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
-  const results = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return [];
+  // Debounce: request baru hanya dikirim 300ms setelah user berhenti
+  // mengetik, supaya tidak ada satu request per keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query.trim()), DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [query]);
 
-    return products
-      .filter((product) => {
-        const categoryName = categoryNameBySlug[product.category] ?? product.category;
-        const collectionName = collectionNameBySlug[product.collection] ?? product.collection;
-        return (
-          product.name.toLowerCase().includes(q) ||
-          categoryName.toLowerCase().includes(q) ||
-          collectionName.toLowerCase().includes(q)
-        );
-      })
-      .slice(0, MAX_RESULTS);
-  }, [query, products, categoryNameBySlug, collectionNameBySlug]);
+  const {
+    data: results,
+    isFetching,
+    isError,
+  } = useQuery({
+    queryKey: ["product-search", debouncedQuery],
+    queryFn: ({signal}) => productSearchRepository.search(debouncedQuery, signal),
+    enabled: debouncedQuery !== "",
+    // Tetap tampilkan hasil lama saat mengetik lanjutan supaya list tidak
+    // berkedip kosong sebelum jawaban baru datang.
+    placeholderData: keepPreviousData,
+  });
 
   if (!open) return null;
+
+  const hasQuery = debouncedQuery !== "";
 
   return (
     <div className="fixed inset-0 z-60">
@@ -106,7 +123,7 @@ export function SearchOverlay({
           </div>
 
           <div className="mt-8">
-            {query.trim() === "" ? (
+            {!hasQuery ? (
               <div className="flex flex-wrap items-baseline gap-6">
                 {/* `items-baseline` (bukan `items-center`) supaya teks "Popular"
                     sejajar dengan teks Chip — Chip punya `pb-1 border-b-2`
@@ -119,9 +136,9 @@ export function SearchOverlay({
                   </Chip>
                 ))}
               </div>
-            ) : results.length === 0 ? (
-              <p className="text-sm text-muted">No pieces match &ldquo;{query}&rdquo;.</p>
-            ) : (
+            ) : isError ? (
+              <p className="text-sm text-muted">Search is unavailable right now. Try again shortly.</p>
+            ) : results && results.length > 0 ? (
               <ul className="divide-y divide-hairline">
                 {results.map((product) => (
                   <li key={product.id}>
@@ -130,20 +147,32 @@ export function SearchOverlay({
                       onClick={handleClose}
                       className="flex items-center gap-4 py-4"
                     >
-                      <div className="size-16 shrink-0">
-                        <PlaceholderImage label={product.name} />
+                      <div className="relative size-16 shrink-0 overflow-hidden">
+                        <RemoteImage src={product.image} alt={product.name} label={product.name} />
                       </div>
-                      <div>
+                      <div className="flex-1">
                         <p className="text-sm">{product.name}</p>
                         <p className="text-xs text-muted">
-                          {categoryNameBySlug[product.category] ?? product.category} ·{" "}
-                          {collectionNameBySlug[product.collection] ?? product.collection}
+                          {isProductSummarySoldOut(product) ? (
+                            "Sold Out"
+                          ) : isProductSummaryOnSale(product) ? (
+                            <>
+                              <span className="text-accent">{formatIDR(product.priceAfterDiscount)}</span>{" "}
+                              <span className="line-through">{formatIDR(product.price)}</span>
+                            </>
+                          ) : (
+                            formatIDR(product.price)
+                          )}
                         </p>
                       </div>
                     </Link>
                   </li>
                 ))}
               </ul>
+            ) : isFetching ? (
+              <p className="text-sm text-muted">Searching…</p>
+            ) : (
+              <p className="text-sm text-muted">No pieces match &ldquo;{debouncedQuery}&rdquo;.</p>
             )}
           </div>
         </div>

--- a/presentation/lib/navigation-fallback.ts
+++ b/presentation/lib/navigation-fallback.ts
@@ -1,0 +1,11 @@
+import type {NavigationMenu} from "@/domain/entities/navigation";
+
+/**
+ * Navbar dirender di root layout, jadi error di sini merusak SELURUH situs.
+ * Fallback-nya sengaja kosong (bukan data hardcode): link statis navbar tetap
+ * berfungsi, dropdown-nya saja yang tidak punya isi — keputusan D6 issue navbar.
+ */
+export const NAVIGATION_FALLBACK: NavigationMenu = {
+  shopGroups: [],
+  collections: [],
+};


### PR DESCRIPTION
Implementasi issue #29 — mengganti data dropdown navbar SHOP & COLLECTION dari mock ke API publik backend.

## Endpoint yang dipakai
- `GET /api/categories?page=1&limit=3` (contract.md Bagian 32) — dropdown SHOP, `limit=3` = 3 room type teratas beserta kategori published di dalamnya (paginasi berlaku per room type, bukan per kategori).
- `GET /api/collections?page=1&limit=10` (contract.md Bagian 34) — dropdown COLLECTION.

## Keputusan desain (D1–D7)
- **D1**: "3 room teratas" = `?page=1&limit=3` apa adanya dari backend — tidak ada kolom `order` untuk room type di contract, jadi frontend tidak menyortir ulang.
- **D2**: Room dengan `categories: []` disembunyikan dari dropdown (bisa kurang dari 3 kolom).
- **D3**: Filter "kategori harus punya produk live" dihapus — endpoint publik sudah published-only, dan slug produk mock tidak akan pernah cocok dengan slug kategori API.
- **D4**: Koleksi = `GET /collections?page=1&limit=10`, `10` = default backend, ditaruh sebagai konstanta bernama.
- **D5**: Entity baru `NavCollection`/`NavRoomGroup` (bukan `Collection`/`Category` lama) — response publik tidak punya `description`/`status`/`visibility`/`room`.
- **D6**: Backend mati → navbar tampil dengan dropdown kosong (jatuh ke link biasa), bukan error. Link statis (SHOP/COLLECTION/CONTACT/SHOWROOM/ABOUT US) tetap berfungsi.
- **D7**: Repository navigasi terpisah (`HttpNavigationRepository`); `MockCategoryRepository`/`MockCollectionRepository` tidak disentuh — `/shop`, `/categories`, `/collections`, `/product/[id]` masih mock dan di luar lingkup issue ini.

## Konsekuensi yang diterima (bukan bug baru)
Link dropdown SHOP mengarah ke `/shop?category=<slug-dari-API>`, sedangkan `/shop` masih memfilter produk **mock** — slug kemungkinan besar tidak cocok, jadi halaman shop akan tampil kosong. Ini normal sampai `/shop` ikut dimigrasikan di issue terpisah.

## Cara menguji
1. Jalankan backend + `bun dev`.
2. Hover **SHOP** → maksimal 3 kolom room dari database (bukan "Living Room / Dining Room / Bed Room" hardcode).
3. Hover **COLLECTION** → daftar koleksi dari database.
4. Lebar < 1024px, buka hamburger → accordion SHOP & COLLECTION sama persis dengan versi desktop.
5. Matikan backend, reload → situs tetap tampil normal, SHOP & COLLECTION jadi link biasa tanpa dropdown (bukan halaman error).
6. `bunx tsc --noEmit`, `bun run lint`, `bun run build` — semua lolos.

Diuji manual di browser terhadap backend lokal: dropdown SHOP menampilkan Bedroom/Dining Room/Living Room nyata dari `GET /api/categories?limit=3`; COLLECTION jatuh ke link biasa karena database saat ini belum punya koleksi `published` (perilaku D6/D7c yang benar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
