### PR TITLE
feat(search): integrasi search product ke GET /api/products

### DIFF
--- a/domain/entities/product-summary.ts
+++ b/domain/entities/product-summary.ts
@@ -1,0 +1,26 @@
+/**
+ * Bentuk ringkas produk untuk listing publik (`productSummary`, contract.md
+ * Bagian 30) — dipakai fitur search. Sengaja terpisah dari `Product`:
+ * endpoint publik hanya mewakili **varian pertama** (bukan termurah/
+ * terpopuler) dan tidak membawa slug kategori/koleksi, deskripsi, dimensi,
+ * dsb. Memaksakan `Product` di sini berarti mengarang field yang tidak ada.
+ */
+export type ProductSummary = {
+  id: string;
+  name: string;
+  sku: string;
+  /** URL gambar varian pertama, atau `undefined` bila belum ada. */
+  image?: string;
+  price: number;
+  discountPercent: number;
+  priceAfterDiscount: number;
+  stock: number;
+};
+
+export function isProductSummarySoldOut(p: ProductSummary): boolean {
+  return p.stock <= 0;
+}
+
+export function isProductSummaryOnSale(p: ProductSummary): boolean {
+  return p.discountPercent > 0 && p.priceAfterDiscount < p.price;
+}

--- a/domain/repositories/product-search-repository.ts
+++ b/domain/repositories/product-search-repository.ts
@@ -1,0 +1,10 @@
+import type {ProductSummary} from "@/domain/entities/product-summary";
+
+export interface ProductSearchRepository {
+  /**
+   * `signal` opsional: dipakai pemanggil client (mis. TanStack Query) untuk
+   * membatalkan request yang sudah usang saat user mengetik lebih cepat dari
+   * jawaban server.
+   */
+  search(query: string, signal?: AbortSignal): Promise<ProductSummary[]>;
+}

--- a/infrastructure/api/endpoints.ts
+++ b/infrastructure/api/endpoints.ts
@@ -5,6 +5,8 @@ export const API_ENDPOINTS = {
     list: "/pages",
   },
   products: {
+    // contract.md Bagian 33 — dipakai fitur search (query `search`).
+    list: "/products",
     detail: (id: string) => `/products/${id}`,
   },
   // Room type + kategori published, dua level sekaligus — contract.md Bagian 32.

--- a/infrastructure/api/mappers/product-summary.ts
+++ b/infrastructure/api/mappers/product-summary.ts
@@ -1,0 +1,18 @@
+import type {ProductSummary} from "@/domain/entities/product-summary";
+import {productSummariesSchema} from "@/infrastructure/api/schemas/product-summary";
+
+export function toProductSummaries(raw: unknown): ProductSummary[] {
+  return productSummariesSchema
+    .parse(raw)
+    .filter((row) => row !== null)
+    .map((row) => ({
+      id: row.id,
+      name: row.name,
+      sku: row.sku,
+      image: row.image ?? undefined,
+      price: row.price,
+      discountPercent: row.discountPercent,
+      priceAfterDiscount: row.priceAfterDiscount,
+      stock: row.stock,
+    }));
+}

--- a/infrastructure/api/schemas/product-summary.ts
+++ b/infrastructure/api/schemas/product-summary.ts
@@ -1,0 +1,22 @@
+import {z} from "zod";
+
+/**
+ * `productSummary` — contract.md Bagian 30 (dipakai `GET /api/products`,
+ * dsb). `.nullable().catch(null)` per item: satu baris yang bentuknya rusak
+ * jadi `null` lalu dibuang di mapper, sisanya tetap tampil. `.catch([])` di
+ * level array adalah jaring terakhir kalau `data` ternyata bukan array.
+ */
+const productSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  sku: z.string(),
+  image: z.string().nullable().catch(null),
+  price: z.number(),
+  discountPercent: z.number(),
+  priceAfterDiscount: z.number(),
+  stock: z.number(),
+});
+
+export const productSummariesSchema = z
+  .array(productSummarySchema.nullable().catch(null))
+  .catch([]);

--- a/infrastructure/repositories/client.ts
+++ b/infrastructure/repositories/client.ts
@@ -1,0 +1,14 @@
+import type {ProductSearchRepository} from "@/domain/repositories/product-search-repository";
+import {HttpProductSearchRepository} from "@/infrastructure/repositories/http-product-search-repository";
+
+/**
+ * Barrel TERPISAH dari `infrastructure/repositories/index.ts` — barrel utama
+ * itu mengimpor repository yang lewat `serverFetch.ts` (`import "server-only"`)
+ * secara statis, jadi mengimpor apa pun darinya dari komponen `"use client"`
+ * ikut menarik kode server-only ke bundle browser dan build gagal.
+ *
+ * Isi berkas ini khusus repository yang aman & memang dipanggil langsung dari
+ * client (transport `apiClient`, bukan `serverFetch`) — saat ini hanya
+ * `productSearchRepository` untuk fitur search product.
+ */
+export const productSearchRepository: ProductSearchRepository = new HttpProductSearchRepository();

--- a/infrastructure/repositories/http-product-search-repository.ts
+++ b/infrastructure/repositories/http-product-search-repository.ts
@@ -1,0 +1,30 @@
+import type {ProductSearchRepository} from "@/domain/repositories/product-search-repository";
+import type {ProductSummary} from "@/domain/entities/product-summary";
+import {API_ENDPOINTS} from "@/infrastructure/api/endpoints";
+import {apiClient} from "@/infrastructure/api/client";
+import {toProductSummaries} from "@/infrastructure/api/mappers/product-summary";
+
+/** Hasil ditampilkan di overlay pencarian, bukan halaman katalog — cukup segenggam. */
+const RESULT_LIMIT = 6;
+
+/**
+ * Beda dari repository lain di folder ini (`Http*` untuk navbar, landing,
+ * dsb): itu semua dipanggil dari Server Component lewat `serverFetch`
+ * (konten yang bisa di-cache/`revalidate`). Pencarian-saat-mengetik murni
+ * interaksi browser — tidak ada render server untuk dihidrasi, jadi transport-
+ * nya `apiClient` (axios), sama seperti endpoint bersesi lain. Dipanggil
+ * langsung dari komponen `"use client"` (`SearchOverlay`), bukan lewat
+ * Server Component + props seperti data navbar.
+ */
+export class HttpProductSearchRepository implements ProductSearchRepository {
+  async search(query: string, signal?: AbortSignal): Promise<ProductSummary[]> {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    const res = await apiClient.get(API_ENDPOINTS.products.list, {
+      params: {search: trimmed, limit: RESULT_LIMIT},
+      signal,
+    });
+    return toProductSummaries(res.data.data);
+  }
+}

--- a/infrastructure/repositories/index.ts
+++ b/infrastructure/repositories/index.ts
@@ -47,3 +47,9 @@ export const infoContentRepository: InfoContentRepository = new HttpInfoContentR
 // categoryRepository/collectionRepository di atas: /shop, /categories, /collections,
 // dan /product/[id] masih memakai mock dan akan dimigrasikan di issue terpisah.
 export const navigationRepository: NavigationRepository = new HttpNavigationRepository();
+
+// `productSearchRepository` (fitur search product) SENGAJA TIDAK ada di sini.
+// Berkas ini mengimpor http-navigation-repository.ts -> server-fetch.ts, yang
+// `import "server-only"` — mengimpor apa pun dari barrel ini di komponen
+// "use client" (search-overlay.tsx) menarik kode server-only itu ke bundle
+// browser dan build gagal. Lihat infrastructure/repositories/client.ts.

--- a/presentation/components/layout/global-overlays.tsx
+++ b/presentation/components/layout/global-overlays.tsx
@@ -3,38 +3,25 @@ import {SearchOverlay} from "@/presentation/components/search/search-overlay";
 import {CartDrawer} from "@/presentation/components/cart/cart-drawer";
 import {AccountDrawer} from "@/presentation/components/account/account-drawer";
 import type {NavCollection, NavRoomGroup} from "@/domain/entities/navigation";
-import type {Category} from "@/domain/entities/category";
-import type {Collection} from "@/domain/entities/collection";
-import type {Product} from "@/domain/entities/product";
 
-/** Overlay global yang dipasang sekali di root layout — mobile menu & search. */
+/**
+ * Overlay global yang dipasang sekali di root layout — mobile menu & search.
+ * `SearchOverlay` tidak lagi menerima produk/kategori/koleksi lewat props
+ * (bagian fitur search product): ia mengambil hasil pencariannya sendiri
+ * dari API lewat `apiClient`, bukan dari data yang di-fetch Server Component
+ * di sini.
+ */
 export function GlobalOverlays({
-  products,
-  categories,
-  collections,
   shopGroups,
   navCollections,
 }: {
-  products: Product[];
-  categories: Category[];
-  // Entity mock — dipakai untuk `collectionNameBySlug` milik SearchOverlay, yang
-  // belum dimigrasikan (di luar lingkup issue navbar). Bukan duplikasi yang
-  // tidak disengaja dengan `navCollections` di bawah, yang datanya dari API.
-  collections: Collection[];
   shopGroups: NavRoomGroup[];
   navCollections: NavCollection[];
 }) {
-  const categoryNameBySlug = Object.fromEntries(categories.map((c) => [c.slug, c.name]));
-  const collectionNameBySlug = Object.fromEntries(collections.map((c) => [c.slug, c.name]));
-
   return (
     <>
       <MobileMenu shopGroups={shopGroups} collections={navCollections} />
-      <SearchOverlay
-        products={products}
-        categoryNameBySlug={categoryNameBySlug}
-        collectionNameBySlug={collectionNameBySlug}
-      />
+      <SearchOverlay />
       <CartDrawer />
       <AccountDrawer />
     </>

--- a/presentation/components/layout/site-chrome.tsx
+++ b/presentation/components/layout/site-chrome.tsx
@@ -1,39 +1,25 @@
 import type {ReactNode} from "react";
 import {getNavigationMenu} from "@/application/use-cases/get-navigation-menu";
-import {getPublishedCategories} from "@/application/use-cases/get-published-categories";
-import {getVisibleCollections} from "@/application/use-cases/get-visible-collections";
-import {getLiveProducts} from "@/application/use-cases/get-live-products";
 import {Navbar} from "@/presentation/components/layout/navbar";
 import {Footer} from "@/presentation/components/layout/footer";
 import {GlobalOverlays} from "@/presentation/components/layout/global-overlays";
 
 /**
  * Kerangka situs (navbar, footer, overlay global) dipasang sekali di root
- * layout. Data kategori/koleksi/produk diambil satu kali di sini lalu
- * diteruskan sebagai props ke Navbar & GlobalOverlays.
+ * layout. Sebelum fitur search product, berkas ini juga mengambil
+ * categories/collections/products mock hanya untuk diteruskan ke
+ * `SearchOverlay`; sekarang `SearchOverlay` mengambil hasil pencariannya
+ * sendiri lewat API, jadi fetch itu dihapus dari sini.
  */
 export async function SiteChrome({children}: {children: ReactNode}) {
-  // `categories`, `collections`, dan `products` di bawah masih dari mock — dipakai
-  // SearchOverlay, yang belum dimigrasikan (di luar lingkup issue navbar).
-  const [navigation, categories, collections, products] = await Promise.all([
-    getNavigationMenu(),
-    getPublishedCategories(),
-    getVisibleCollections(),
-    getLiveProducts(),
-  ]);
+  const navigation = await getNavigationMenu();
 
   return (
     <>
       <Navbar shopGroups={navigation.shopGroups} collections={navigation.collections} />
       {children}
       <Footer />
-      <GlobalOverlays
-        products={products}
-        categories={categories}
-        collections={collections}
-        shopGroups={navigation.shopGroups}
-        navCollections={navigation.collections}
-      />
+      <GlobalOverlays shopGroups={navigation.shopGroups} navCollections={navigation.collections} />
     </>
   );
 }

--- a/presentation/components/search/search-overlay.tsx
+++ b/presentation/components/search/search-overlay.tsx
@@ -1,38 +1,52 @@
 "use client";
 
-import {useEffect, useMemo, useRef, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import Link from "next/link";
+import {useQuery, keepPreviousData} from "@tanstack/react-query";
 import {Chip} from "@/presentation/components/ui/chip";
-import {PlaceholderImage} from "@/presentation/components/ui/placeholder-image";
+import {RemoteImage} from "@/presentation/components/ui/remote-image";
 import {Icon} from "@/presentation/components/icon";
 import {ICONS} from "@/presentation/components/icons";
 import {useUi} from "@/presentation/providers/ui-provider";
-import type {Product} from "@/domain/entities/product";
+import {productSearchRepository} from "@/infrastructure/repositories/client";
+import {isProductSummaryOnSale, isProductSummarySoldOut} from "@/domain/entities/product-summary";
+import {formatIDR} from "@/presentation/lib/format";
 
 const POPULAR_TERMS = ["Sofa", "Lounge Chair", "Dining Table", "Solana Lounge Chair"];
-const MAX_RESULTS = 6;
 const AUTOFOCUS_DELAY_MS = 320;
+/** User berhenti mengetik selama ini sebelum request dikirim — bagian fitur search product. */
+const DEBOUNCE_MS = 300;
 
-export type SearchOverlayProps = {
-  products: Product[];
-  categoryNameBySlug: Record<string, string>;
-  collectionNameBySlug: Record<string, string>;
-};
-
-/** Sheet pencarian turun dari atas — bagian 3.5 issue.md. */
-export function SearchOverlay({
-  products,
-  categoryNameBySlug,
-  collectionNameBySlug,
-}: SearchOverlayProps) {
+/**
+ * Sheet pencarian turun dari atas — bagian 3.5 issue.md, disambungkan ke
+ * `GET /api/products?search=` (contract.md Bagian 33 — fitur search
+ * product). Sengaja tidak lagi menerima daftar produk lewat props seperti
+ * sebelumnya: pencarian-saat-mengetik adalah interaksi browser murni, jadi
+ * repository-nya dipanggil langsung dari sini lewat `apiClient`
+ * (`HttpProductSearchRepository`), bukan lewat props dari Server Component.
+ *
+ * `productSummary` (bentuk hasil API, lihat `domain/entities/product-summary.ts`)
+ * tidak membawa slug kategori/koleksi seperti entity `Product` mock — jadi
+ * subtitle di bawah nama produk sekarang menampilkan harga, bukan
+ * "Kategori · Koleksi" seperti versi mock.
+ *
+ * Konsekuensi yang diterima (sama pola dengan issue navbar #29 soal /shop):
+ * `/product/[id]` masih 100% mock, sedangkan id hasil pencarian ini adalah
+ * UUID asli dari backend — klik hasil pencarian kemungkinan besar mengarah
+ * ke halaman produk kosong sampai `/product/[id]` ikut dimigrasikan di issue
+ * terpisah.
+ */
+export function SearchOverlay() {
   const {isOpen, close} = useUi();
   const open = isOpen("search");
   const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
   function handleClose() {
     close();
     setQuery("");
+    setDebouncedQuery("");
   }
 
   useEffect(() => {
@@ -45,34 +59,37 @@ export function SearchOverlay({
     if (!open) return;
 
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        close();
-        setQuery("");
-      }
+      if (event.key === "Escape") handleClose();
     }
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open, close]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
-  const results = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return [];
+  // Debounce: request baru hanya dikirim 300ms setelah user berhenti
+  // mengetik, supaya tidak ada satu request per keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query.trim()), DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [query]);
 
-    return products
-      .filter((product) => {
-        const categoryName = categoryNameBySlug[product.category] ?? product.category;
-        const collectionName = collectionNameBySlug[product.collection] ?? product.collection;
-        return (
-          product.name.toLowerCase().includes(q) ||
-          categoryName.toLowerCase().includes(q) ||
-          collectionName.toLowerCase().includes(q)
-        );
-      })
-      .slice(0, MAX_RESULTS);
-  }, [query, products, categoryNameBySlug, collectionNameBySlug]);
+  const {
+    data: results,
+    isFetching,
+    isError,
+  } = useQuery({
+    queryKey: ["product-search", debouncedQuery],
+    queryFn: ({signal}) => productSearchRepository.search(debouncedQuery, signal),
+    enabled: debouncedQuery !== "",
+    // Tetap tampilkan hasil lama saat mengetik lanjutan supaya list tidak
+    // berkedip kosong sebelum jawaban baru datang.
+    placeholderData: keepPreviousData,
+  });
 
   if (!open) return null;
+
+  const hasQuery = debouncedQuery !== "";
 
   return (
     <div className="fixed inset-0 z-60">
@@ -106,7 +123,7 @@ export function SearchOverlay({
           </div>
 
           <div className="mt-8">
-            {query.trim() === "" ? (
+            {!hasQuery ? (
               <div className="flex flex-wrap items-baseline gap-6">
                 {/* `items-baseline` (bukan `items-center`) supaya teks "Popular"
                     sejajar dengan teks Chip — Chip punya `pb-1 border-b-2`
@@ -119,9 +136,9 @@ export function SearchOverlay({
                   </Chip>
                 ))}
               </div>
-            ) : results.length === 0 ? (
-              <p className="text-sm text-muted">No pieces match &ldquo;{query}&rdquo;.</p>
-            ) : (
+            ) : isError ? (
+              <p className="text-sm text-muted">Search is unavailable right now. Try again shortly.</p>
+            ) : results && results.length > 0 ? (
               <ul className="divide-y divide-hairline">
                 {results.map((product) => (
                   <li key={product.id}>
@@ -130,20 +147,32 @@ export function SearchOverlay({
                       onClick={handleClose}
                       className="flex items-center gap-4 py-4"
                     >
-                      <div className="size-16 shrink-0">
-                        <PlaceholderImage label={product.name} />
+                      <div className="relative size-16 shrink-0 overflow-hidden">
+                        <RemoteImage src={product.image} alt={product.name} label={product.name} />
                       </div>
-                      <div>
+                      <div className="flex-1">
                         <p className="text-sm">{product.name}</p>
                         <p className="text-xs text-muted">
-                          {categoryNameBySlug[product.category] ?? product.category} ·{" "}
-                          {collectionNameBySlug[product.collection] ?? product.collection}
+                          {isProductSummarySoldOut(product) ? (
+                            "Sold Out"
+                          ) : isProductSummaryOnSale(product) ? (
+                            <>
+                              <span className="text-accent">{formatIDR(product.priceAfterDiscount)}</span>{" "}
+                              <span className="line-through">{formatIDR(product.price)}</span>
+                            </>
+                          ) : (
+                            formatIDR(product.price)
+                          )}
                         </p>
                       </div>
                     </Link>
                   </li>
                 ))}
               </ul>
+            ) : isFetching ? (
+              <p className="text-sm text-muted">Searching…</p>
+            ) : (
+              <p className="text-sm text-muted">No pieces match &ldquo;{debouncedQuery}&rdquo;.</p>
             )}
           </div>
         </div>


### PR DESCRIPTION
Fitur search product — menyambungkan search overlay ke `GET /api/products?search=` (contract.md Bagian 33), menggantikan filter client-side di atas daftar produk mock.

> **Bergantung pada #30** (integrasi navbar). Base branch PR ini adalah `feat/issue-29-navbar-api`, bukan `main` — `site-chrome.tsx` di PR ini mengasumsikan `shopGroups`/`navCollections` sudah datang dari `getNavigationMenu()` (bukan `buildShopMenuGroups` + mock), jadi PR ini sebaiknya di-review/merge **setelah** #30.

## Yang berubah
- **Repository baru**: `ProductSummary` (entity), `ProductSearchRepository` (interface), `HttpProductSearchRepository` (implementasi, pakai `apiClient` bukan `serverFetch` — lihat di bawah).
- **`SearchOverlay`**: tidak lagi menerima produk/kategori/koleksi lewat props. Mengambil hasil pencariannya sendiri lewat `apiClient` + TanStack Query, dengan **debounce 300ms** supaya tidak ada satu request per keystroke.
- **Subtitle hasil pencarian berubah**: dari "Kategori · Koleksi" jadi **harga** (dengan badge diskon/sold out) — `productSummary` dari API publik tidak membawa slug kategori/koleksi seperti entity `Product` mock.
- **`site-chrome.tsx` & `global-overlays.tsx` disederhanakan**: fetch `getPublishedCategories`/`getVisibleCollections`/`getLiveProducts` di root layout dihapus, karena sebelumnya cuma dipakai `SearchOverlay` versi mock. Masing-masing halaman (`/shop`, `/categories`, `/collections`, PDP) sudah fetch sendiri, jadi tidak terdampak.

## Catatan arsitektur penting
`HttpProductSearchRepository` **tidak** didaftarkan di `infrastructure/repositories/index.ts` seperti repository lain — barrel itu mengimpor `http-navigation-repository.ts` → `server-fetch.ts` yang `import "server-only"`, jadi mengimpor apa pun darinya dari komponen `"use client"` (`SearchOverlay`) menarik kode server-only ke bundle browser dan **build gagal** (sempat kejadian, sudah diperbaiki). Repository ini didaftarkan di barrel terpisah: `infrastructure/repositories/client.ts`.

## Konsekuensi yang diterima (pola sama dengan #30 soal `/shop`)
`/product/[id]` masih 100% mock, sedangkan id hasil pencarian adalah UUID asli dari backend. Klik hasil pencarian akan mengarah ke halaman produk yang **404 "Page Not Found"** (halaman not-found situs, bukan crash) sampai `/product/[id]` ikut dimigrasikan ke API di issue terpisah.

## Cara menguji
1. Jalankan backend + `bun dev`.
2. Buka overlay pencarian, ketik nama produk yang ada di database → hasil nyata (gambar, nama, harga) muncul.
3. Ketik query tanpa hasil → pesan "No pieces match ..." (bukan error/crash).
4. Klik salah satu chip "Popular" → memicu pencarian nyata dengan kata itu.
5. `bunx tsc --noEmit`, `bun run lint`, `bun run build` — semua lolos.

Diuji manual di browser terhadap backend lokal: ketik "oak" → 1 hasil nyata ("Oak Coffee Table", IDR 2.000.000) muncul; network tab mengonfirmasi **1 request** untuk 3 keystroke (debounce jalan); klik hasil → 404 rapi sesuai konsekuensi di atas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
