### PR TITLE
feat(wishlist): integrasi API Wishlist (/api/wishlists)

### DIFF
--- a/application/hooks/use-saved-products.ts
+++ b/application/hooks/use-saved-products.ts
@@ -1,18 +1,49 @@
 "use client";
 
 import {useMemo} from "react";
-import {useWishlist} from "@/presentation/providers/wishlist-provider";
-import {MOCK_PRODUCTS} from "@/infrastructure/mock/data/products";
+import {useInfiniteQuery} from "@tanstack/react-query";
+import type {ProductSummary} from "@/domain/entities/product-summary";
+import {wishlistRepository} from "@/infrastructure/repositories/client";
+import {useAuth} from "@/presentation/providers/auth-provider";
+import {wishlistListKey} from "@/presentation/providers/wishlist-provider";
+
+/** Sama dengan default backend (contract.md Bagian 35). */
+const PAGE_SIZE = 12;
 
 /**
- * Produk yang tersimpan di wishlist pengguna saat ini. Mengambil langsung
- * dari data mock (client-safe, sinkron) — diganti dengan query API begitu
- * ISSUE-15 selesai.
+ * Produk yang tersimpan di wishlist user — langsung dari `GET /api/wishlists`
+ * (contract.md Bagian 35), berpaginasi dengan tombol "Load More".
+ *
+ * Sengaja TERPISAH dari daftar sku di `WishlistProvider`: provider butuh
+ * SELURUH sku untuk menentukan state hati di kartu produk manapun, sedangkan
+ * layar Saved Pieces hanya perlu halaman yang sedang dilihat user.
  */
 export function useSavedProducts() {
-  const {productIds} = useWishlist();
-  return useMemo(
-    () => MOCK_PRODUCTS.filter((product) => productIds.includes(product.id)),
-    [productIds]
+  const {user} = useAuth();
+  const userId = user?.id ?? null;
+
+  const query = useInfiniteQuery({
+    queryKey: wishlistListKey(userId),
+    enabled: userId !== null,
+    initialPageParam: 1,
+    queryFn: ({pageParam, signal}) => wishlistRepository.listPage(pageParam, PAGE_SIZE, signal),
+    getNextPageParam: (lastPage) =>
+      lastPage.meta.page < lastPage.meta.totalPages ? lastPage.meta.page + 1 : undefined,
+  });
+
+  const products = useMemo<ProductSummary[]>(
+    () => query.data?.pages.flatMap((page) => page.items.map((item) => item.product)) ?? [],
+    [query.data]
   );
+
+  return {
+    products,
+    // `isPending` tetap true selama query disabled (React Query v5) — untuk
+    // tamu itu bukan "sedang memuat", jadi harus digabung dengan cek userId.
+    isLoading: userId !== null && query.isPending,
+    isError: query.isError,
+    hasMore: query.hasNextPage,
+    isLoadingMore: query.isFetchingNextPage,
+    loadMore: () => query.fetchNextPage(),
+  };
 }

--- a/domain/entities/wishlist-item.ts
+++ b/domain/entities/wishlist-item.ts
@@ -1,0 +1,11 @@
+import type {ProductSummary} from "@/domain/entities/product-summary";
+
+/**
+ * Satu baris wishlist milik user — contract.md Bagian 35. `id` adalah id baris
+ * wishlist (bukan id produk); yang dipakai untuk menambah/menghapus adalah
+ * `product.sku` (`products.base_sku`).
+ */
+export type WishlistItem = {
+  id: string;
+  product: ProductSummary;
+};

--- a/domain/repositories/wishlist-repository.ts
+++ b/domain/repositories/wishlist-repository.ts
@@ -1,0 +1,18 @@
+import type {PageMeta} from "@/domain/entities/pagination";
+import type {WishlistItem} from "@/domain/entities/wishlist-item";
+
+export type WishlistPage = {items: WishlistItem[]; meta: PageMeta};
+
+/**
+ * Wishlist user website — contract.md Bagian 35. Seluruh method butuh sesi
+ * login user (cookie better-auth); tanpa sesi backend membalas 401.
+ */
+export interface WishlistRepository {
+  /** Satu halaman wishlist untuk UI "Saved Pieces". */
+  listPage(page: number, limit: number, signal?: AbortSignal): Promise<WishlistPage>;
+  /** Seluruh sku tersimpan — dipakai menentukan state hati di kartu produk. */
+  listAllSkus(signal?: AbortSignal): Promise<string[]>;
+  /** Idempoten di sisi backend: menambah sku yang sudah ada bukan error. */
+  add(sku: string): Promise<void>;
+  remove(sku: string): Promise<void>;
+}

--- a/infrastructure/api/endpoints.ts
+++ b/infrastructure/api/endpoints.ts
@@ -19,6 +19,14 @@ export const API_ENDPOINTS = {
   collections: {
     list: "/collections",
   },
+  // contract.md Bagian 35. BUKAN "/admin/wishlists" (tidak ada di kontrak) dan
+  // BUKAN "/api/wishlists" — base URL sudah mengandung /api.
+  wishlists: {
+    list: "/wishlists",
+    add: "/wishlists",
+    /** `sku` = products.base_sku, bukan id baris wishlist. */
+    remove: (sku: string) => `/wishlists/${encodeURIComponent(sku)}`,
+  },
   // contract.md Bagian 37. BUKAN "/admin/jobs" (Bagian 26, endpoint dashboard
   // admin dengan bentuk data berbeda) dan BUKAN "/api/careers" (base URL sudah
   // mengandung /api).

--- a/infrastructure/api/mappers/wishlist.ts
+++ b/infrastructure/api/mappers/wishlist.ts
@@ -1,0 +1,22 @@
+import type {WishlistItem} from "@/domain/entities/wishlist-item";
+import {wishlistItemsSchema} from "@/infrastructure/api/schemas/wishlist";
+
+export function toWishlistItems(raw: unknown): WishlistItem[] {
+  return wishlistItemsSchema
+    .parse(raw)
+    .filter((row) => row !== null)
+    .map((row) => ({
+      id: row.id,
+      product: {
+        id: row.product.id,
+        name: row.product.name,
+        sku: row.product.sku,
+        // `null` dari API -> `undefined` di entity, sama seperti mapper lain.
+        image: row.product.image ?? undefined,
+        price: row.product.price,
+        discountPercent: row.product.discountPercent,
+        priceAfterDiscount: row.product.priceAfterDiscount,
+        stock: row.product.stock,
+      },
+    }));
+}

--- a/infrastructure/api/schemas/product-summary.ts
+++ b/infrastructure/api/schemas/product-summary.ts
@@ -6,7 +6,7 @@ import {z} from "zod";
  * jadi `null` lalu dibuang di mapper, sisanya tetap tampil. `.catch([])` di
  * level array adalah jaring terakhir kalau `data` ternyata bukan array.
  */
-const productSummarySchema = z.object({
+export const productSummarySchema = z.object({
   id: z.string(),
   name: z.string(),
   sku: z.string(),

--- a/infrastructure/api/schemas/wishlist.ts
+++ b/infrastructure/api/schemas/wishlist.ts
@@ -1,0 +1,16 @@
+import {z} from "zod";
+import {productSummarySchema} from "@/infrastructure/api/schemas/product-summary";
+
+/**
+ * Baris `GET /api/wishlists` — contract.md Bagian 35. Pola defensif sama dengan
+ * product-summary.ts: satu baris rusak jadi `null` lalu dibuang di mapper,
+ * sisanya tetap tampil.
+ */
+const wishlistItemSchema = z.object({
+  id: z.string(),
+  product: productSummarySchema,
+});
+
+export const wishlistItemsSchema = z
+  .array(wishlistItemSchema.nullable().catch(null))
+  .catch([]);

--- a/infrastructure/repositories/client.ts
+++ b/infrastructure/repositories/client.ts
@@ -1,7 +1,9 @@
 import type {ProductSearchRepository} from "@/domain/repositories/product-search-repository";
 import type {CareerDetailRepository} from "@/domain/repositories/career-repository";
+import type {WishlistRepository} from "@/domain/repositories/wishlist-repository";
 import {HttpProductSearchRepository} from "@/infrastructure/repositories/http-product-search-repository";
 import {HttpCareerDetailRepository} from "@/infrastructure/repositories/http-career-detail-repository";
+import {HttpWishlistRepository} from "@/infrastructure/repositories/http-wishlist-repository";
 
 /**
  * Barrel TERPISAH dari `infrastructure/repositories/index.ts` — barrel utama
@@ -12,8 +14,11 @@ import {HttpCareerDetailRepository} from "@/infrastructure/repositories/http-car
  * Isi berkas ini khusus repository yang aman & memang dipanggil langsung dari
  * client (transport `apiClient`, bukan `serverFetch`) — `productSearchRepository`
  * untuk fitur search product, `careerDetailRepository` untuk detail lowongan
- * (issue #36, D5).
+ * (issue #36, D5), `wishlistRepository` untuk wishlist user (issue #38, D7) —
+ * dipanggil dari `WishlistProvider` yang `"use client"`.
  */
 export const productSearchRepository: ProductSearchRepository = new HttpProductSearchRepository();
 
 export const careerDetailRepository: CareerDetailRepository = new HttpCareerDetailRepository();
+
+export const wishlistRepository: WishlistRepository = new HttpWishlistRepository();

--- a/infrastructure/repositories/http-wishlist-repository.ts
+++ b/infrastructure/repositories/http-wishlist-repository.ts
@@ -1,0 +1,52 @@
+import type {WishlistPage, WishlistRepository} from "@/domain/repositories/wishlist-repository";
+import {API_ENDPOINTS} from "@/infrastructure/api/endpoints";
+import {apiClient} from "@/infrastructure/api/client";
+import {toPageMeta} from "@/infrastructure/api/mappers/catalog";
+import {toWishlistItems} from "@/infrastructure/api/mappers/wishlist";
+
+/** Limit besar khusus pemindaian sku (state hati), bukan untuk UI. */
+const SKU_SCAN_LIMIT = 100;
+/** Jaring pengaman kalau `meta.totalPages` dari server tidak masuk akal. */
+const MAX_SCAN_PAGES = 20;
+
+/**
+ * Wishlist user — contract.md Bagian 35. Transport `apiClient` (axios), bukan
+ * `serverFetch`: seluruh operasinya dipicu interaksi browser dan bergantung
+ * pada cookie sesi better-auth milik user, jadi tidak ada yang bisa dirender
+ * atau di-cache di server.
+ */
+export class HttpWishlistRepository implements WishlistRepository {
+  async listPage(page: number, limit: number, signal?: AbortSignal): Promise<WishlistPage> {
+    const res = await apiClient.get(API_ENDPOINTS.wishlists.list, {
+      params: {page, limit},
+      signal,
+    });
+    // `res.data` = envelope {data, meta}.
+    return {items: toWishlistItems(res.data.data), meta: toPageMeta(res.data.meta)};
+  }
+
+  async listAllSkus(signal?: AbortSignal): Promise<string[]> {
+    const skus: string[] = [];
+    let page = 1;
+    let totalPages = 1;
+
+    do {
+      const {items, meta} = await this.listPage(page, SKU_SCAN_LIMIT, signal);
+      for (const item of items) skus.push(item.product.sku);
+      totalPages = meta.totalPages;
+      page += 1;
+    } while (page <= totalPages && page <= MAX_SCAN_PAGES);
+
+    return skus;
+  }
+
+  async add(sku: string): Promise<void> {
+    // Idempoten di backend: 201 kalau baru, 200 kalau sudah ada. Keduanya
+    // sukses, jadi tidak perlu dibedakan di sini.
+    await apiClient.post(API_ENDPOINTS.wishlists.add, {sku});
+  }
+
+  async remove(sku: string): Promise<void> {
+    await apiClient.delete(API_ENDPOINTS.wishlists.remove(sku));
+  }
+}

--- a/presentation/components/account/account-drawer.tsx
+++ b/presentation/components/account/account-drawer.tsx
@@ -8,7 +8,7 @@ import {z} from "zod";
 import {Drawer} from "@/presentation/components/ui/drawer";
 import {FormField} from "@/presentation/components/ui/form-field";
 import {Button} from "@/presentation/components/ui/button";
-import {PlaceholderImage} from "@/presentation/components/ui/placeholder-image";
+import {RemoteImage} from "@/presentation/components/ui/remote-image";
 import {Icon} from "@/presentation/components/icon";
 import {ICONS} from "@/presentation/components/icons";
 import {useAuth} from "@/presentation/providers/auth-provider";
@@ -60,7 +60,14 @@ export function AccountDrawer() {
   const open = isOpen("account");
   const {user, signIn, signUp, signOut} = useAuth();
   const {toast} = useToast();
-  const savedProducts = useSavedProducts();
+  const {
+    products: savedProducts,
+    isLoading: savedLoading,
+    isError: savedError,
+    hasMore: savedHasMore,
+    isLoadingMore: savedLoadingMore,
+    loadMore: loadMoreSaved,
+  } = useSavedProducts();
 
   const [mode, setMode] = useState<GuestMode>("signin");
   const [formError, setFormError] = useState<string | undefined>();
@@ -143,25 +150,44 @@ export function AccountDrawer() {
 
             <div className="mt-10">
               <h3 className="text-xs uppercase tracking-label text-muted">Saved Pieces</h3>
-              {savedProducts.length === 0 ? (
+              {savedLoading ? (
+                <p className="mt-3 text-sm text-muted">Loading your saved pieces…</p>
+              ) : savedError ? (
+                <p className="mt-3 text-sm text-muted">
+                  Saved pieces are unavailable right now. Please try again shortly.
+                </p>
+              ) : savedProducts.length === 0 ? (
                 <p className="mt-3 text-sm text-muted">Pieces you save will appear here.</p>
               ) : (
-                <div className="mt-4 grid grid-cols-2 gap-4">
-                  {savedProducts.map((product) => (
-                    <Link
-                      key={product.id}
-                      href={`/product/${product.id}`}
-                      onClick={close}
-                      className="block"
-                    >
-                      <div className="aspect-square bg-warm">
-                        <PlaceholderImage label={product.name} />
-                      </div>
-                      <p className="mt-2 text-xs">{product.name}</p>
-                      <p className="text-xs text-muted">{formatIDR(product.price)}</p>
-                    </Link>
-                  ))}
-                </div>
+                <>
+                  <div className="mt-4 grid grid-cols-2 gap-4">
+                    {savedProducts.map((product) => (
+                      <Link
+                        key={product.id}
+                        href={`/product/${product.sku}`}
+                        onClick={close}
+                        className="block"
+                      >
+                        {/* RemoteImage memakai `fill` — pembungkusnya wajib relative + overflow-hidden. */}
+                        <div className="relative aspect-square overflow-hidden bg-warm">
+                          <RemoteImage
+                            src={product.image}
+                            alt={product.name}
+                            label={product.name}
+                            sizes="(min-width: 640px) 20vw, 40vw"
+                          />
+                        </div>
+                        <p className="mt-2 text-xs">{product.name}</p>
+                        <p className="text-xs text-muted">{formatIDR(product.priceAfterDiscount)}</p>
+                      </Link>
+                    ))}
+                  </div>
+                  {savedHasMore ? (
+                    <Button className="mt-4 w-full" onClick={loadMoreSaved} disabled={savedLoadingMore}>
+                      {savedLoadingMore ? "Loading…" : "Load More"}
+                    </Button>
+                  ) : null}
+                </>
               )}
             </div>
 

--- a/presentation/components/account/account-page.tsx
+++ b/presentation/components/account/account-page.tsx
@@ -9,7 +9,7 @@ import {Button} from "@/presentation/components/ui/button";
 import {Container} from "@/presentation/components/ui/container";
 import {Eyebrow} from "@/presentation/components/ui/eyebrow";
 import {FormField} from "@/presentation/components/ui/form-field";
-import {PlaceholderImage} from "@/presentation/components/ui/placeholder-image";
+import {RemoteImage} from "@/presentation/components/ui/remote-image";
 import {useAuth} from "@/presentation/providers/auth-provider";
 import {useToast} from "@/presentation/providers/toast-provider";
 import {useSavedProducts} from "@/application/hooks/use-saved-products";
@@ -39,7 +39,14 @@ type ProfileValues = z.infer<typeof profileSchema>;
 export function AccountPage() {
   const {user, signOut, updateProfile} = useAuth();
   const {toast} = useToast();
-  const savedProducts = useSavedProducts();
+  const {
+    products: savedProducts,
+    isLoading: savedLoading,
+    isError: savedError,
+    hasMore: savedHasMore,
+    isLoadingMore: savedLoadingMore,
+    loadMore: loadMoreSaved,
+  } = useSavedProducts();
   const [profileError, setProfileError] = useState<string | undefined>();
 
   const profileForm = useForm<ProfileValues>({
@@ -117,20 +124,39 @@ export function AccountPage() {
 
         <div>
           <h2 className="text-xs uppercase tracking-label text-muted">Saved Pieces</h2>
-          {savedProducts.length === 0 ? (
+          {savedLoading ? (
+            <p className="mt-4 text-sm text-muted">Loading your saved pieces…</p>
+          ) : savedError ? (
+            <p className="mt-4 text-sm text-muted">
+              Saved pieces are unavailable right now. Please try again shortly.
+            </p>
+          ) : savedProducts.length === 0 ? (
             <p className="mt-4 text-sm text-muted">Pieces you save will appear here.</p>
           ) : (
-            <div className="mt-4 grid grid-cols-2 gap-6 sm:grid-cols-3">
-              {savedProducts.map((product) => (
-                <Link key={product.id} href={`/product/${product.id}`} className="block">
-                  <div className="aspect-square bg-warm">
-                    <PlaceholderImage label={product.name} />
-                  </div>
-                  <p className="mt-2 text-xs">{product.name}</p>
-                  <p className="text-xs text-muted">{formatIDR(product.price)}</p>
-                </Link>
-              ))}
-            </div>
+            <>
+              <div className="mt-4 grid grid-cols-2 gap-6 sm:grid-cols-3">
+                {savedProducts.map((product) => (
+                  <Link key={product.id} href={`/product/${product.sku}`} className="block">
+                    {/* RemoteImage memakai `fill` — pembungkusnya wajib relative + overflow-hidden. */}
+                    <div className="relative aspect-square overflow-hidden bg-warm">
+                      <RemoteImage
+                        src={product.image}
+                        alt={product.name}
+                        label={product.name}
+                        sizes="(min-width: 640px) 20vw, 40vw"
+                      />
+                    </div>
+                    <p className="mt-2 text-xs">{product.name}</p>
+                    <p className="text-xs text-muted">{formatIDR(product.priceAfterDiscount)}</p>
+                  </Link>
+                ))}
+              </div>
+              {savedHasMore ? (
+                <Button className="mt-6" onClick={loadMoreSaved} disabled={savedLoadingMore}>
+                  {savedLoadingMore ? "Loading…" : "Load More"}
+                </Button>
+              ) : null}
+            </>
           )}
         </div>
       </div>

--- a/presentation/components/product/featured-product-card.tsx
+++ b/presentation/components/product/featured-product-card.tsx
@@ -14,7 +14,7 @@ export type FeaturedProductCardProps = {
  * Kartu produk "Designed for Life" — bagian Fase 6 issue #27. Kartu terpisah
  * dari `ProductCard`: tanpa harga, tanpa `QuickAddButton` (entity
  * `FeaturedProduct` memang tidak membawa data itu), tetap ada
- * `WishlistButton` karena hanya butuh `productId` + `productName`.
+ * `WishlistButton` karena hanya butuh `sku` + `productName`.
  */
 export function FeaturedProductCard({product, className}: FeaturedProductCardProps) {
   return (
@@ -37,7 +37,7 @@ export function FeaturedProductCard({product, className}: FeaturedProductCardPro
         ) : null}
 
         <WishlistButton
-          productId={product.id}
+          sku={product.sku}
           productName={product.name}
           className="absolute right-4 top-4"
         />

--- a/presentation/components/product/product-card.tsx
+++ b/presentation/components/product/product-card.tsx
@@ -45,7 +45,7 @@ export function ProductCard({
         ) : null}
 
         <WishlistButton
-          productId={product.id}
+          sku={product.sku}
           productName={product.name}
           className="absolute right-4 top-4"
         />

--- a/presentation/components/product/product-summary-card.tsx
+++ b/presentation/components/product/product-summary-card.tsx
@@ -54,7 +54,7 @@ export function ProductSummaryCard({product, showPrice = true, className}: Produ
         ) : null}
 
         <WishlistButton
-          productId={product.id}
+          sku={product.sku}
           productName={product.name}
           className="absolute right-4 top-4"
         />

--- a/presentation/components/product/wishlist-button.tsx
+++ b/presentation/components/product/wishlist-button.tsx
@@ -8,7 +8,7 @@ import {cn} from "@/presentation/lib/cn";
 import {useWishlist} from "@/presentation/providers/wishlist-provider";
 
 export type WishlistButtonProps = {
-  productId: string;
+  sku: string;
   productName: string;
   className?: string;
 };
@@ -16,28 +16,30 @@ export type WishlistButtonProps = {
 /**
  * Tombol wishlist — komponen terpisah dari ProductCard (bagian 6.2 issue.md).
  *
- * Sengaja TIDAK digerbang oleh status login (beda dari sebelum ISSUE-17):
- * tamu boleh menyimpan wishlist lokal (`khena.wishlist.guest`) yang nanti
- * digabung otomatis ke akun begitu dia sign in — lihat wishlist-provider.tsx
- * bagian 8a issue.md. Menyembunyikan tombol ini untuk tamu akan membuat fitur
- * itu tidak pernah bisa dipakai dari UI.
+ * Wishlist wajib login (D2 issue #38): tamu yang menekan tombol ini tidak
+ * menyimpan apa pun, melainkan diarahkan ke drawer sign in oleh
+ * `WishlistProvider`. Menyembunyikan tombol untuk tamu tetap tidak dilakukan
+ * supaya ajakan sign in itu terlihat.
  */
-export function WishlistButton({productId, productName, className}: WishlistButtonProps) {
+export function WishlistButton({sku, productName, className}: WishlistButtonProps) {
   const {isSaved, toggle} = useWishlist();
   const [pulse, setPulse] = useState<"save" | "remove" | null>(null);
-  const saved = isSaved(productId);
+  const saved = isSaved(sku);
 
   function handleClick(event: MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
     event.stopPropagation();
-    const outcome = toggle(productId);
+    const outcome = toggle(sku);
+    // Tamu diarahkan ke drawer sign in oleh provider — tidak ada perubahan
+    // state wishlist, jadi jangan memutar animasi seolah-olah tersimpan.
+    if (outcome === "signin-required") return;
     setPulse(outcome === "saved" ? "save" : "remove");
   }
 
   return (
     <button
       type="button"
-      data-product-id={productId}
+      data-sku={sku}
       aria-label={saved ? `Remove ${productName} from wishlist` : `Save ${productName} to wishlist`}
       aria-pressed={saved}
       onClick={handleClick}

--- a/presentation/providers/wishlist-provider.tsx
+++ b/presentation/providers/wishlist-provider.tsx
@@ -1,126 +1,142 @@
 "use client";
 
-import {createContext, useCallback, useContext, useEffect, useMemo, useRef, useState} from "react";
+import {createContext, useCallback, useContext, useEffect, useMemo} from "react";
 import type {ReactNode} from "react";
+import {useMutation, useQuery, useQueryClient} from "@tanstack/react-query";
+import {ApiError} from "@/infrastructure/api/client";
+import {wishlistRepository} from "@/infrastructure/repositories/client";
 import {useAuth} from "@/presentation/providers/auth-provider";
+import {useToast} from "@/presentation/providers/toast-provider";
+import {useUi} from "@/presentation/providers/ui-provider";
+
+/** Hasil `toggle` — dipakai WishlistButton untuk memilih animasi. */
+export type WishlistToggleOutcome = "saved" | "removed" | "signin-required";
 
 type WishlistContextValue = {
-  productIds: string[];
-  isSaved: (productId: string) => boolean;
-  toggle: (productId: string) => "saved" | "removed";
+  savedSkus: string[];
+  isSaved: (sku: string) => boolean;
+  toggle: (sku: string) => WishlistToggleOutcome;
 };
 
 const WishlistContext = createContext<WishlistContextValue | null>(null);
 
-/** Wishlist tamu (belum login) — digabung ke wishlist user saat login. */
-const GUEST_STORAGE_KEY = "khena.wishlist.guest";
+/**
+ * Query key wishlist. `userId` ikut masuk key supaya wishlist user lama tidak
+ * pernah terlihat oleh user berikutnya — jadi tidak perlu membersihkan cache
+ * secara manual saat sign out.
+ */
+export const wishlistSkusKey = (userId: string | null) => ["wishlist", "skus", userId] as const;
+export const wishlistListKey = (userId: string | null) => ["wishlist", "list", userId] as const;
 
-function storageKey(userId: string) {
-  return `khena.wishlist.${userId}`;
-}
+/** Prefix untuk invalidate kedua query sekaligus setelah mutasi. */
+const WISHLIST_KEY_PREFIX = ["wishlist"] as const;
 
-function readList(key: string): string[] {
-  try {
-    const raw = window.localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as string[]) : [];
-  } catch {
-    return [];
+function wishlistErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.isUnauthorized) return "Your session has expired. Please sign in again.";
+    // 400 di kontrak ini berarti "product not found" (POST) atau
+    // "wishlist not found" (DELETE) — dua-duanya tidak bisa diperbaiki user
+    // dengan mencoba lagi, jadi pesannya bukan "please try again".
+    if (error.status === 400) return "This piece is no longer available.";
   }
+  return "Could not update your wishlist. Please try again.";
 }
 
 /**
- * Wishlist per pengguna.
- *
- * PENYIMPANAN SEMENTARA (bagian 8a/8b issue.md): masih di localStorage,
- * karena belum ada satu pun endpoint bisnis yang memakai sesi user
- * (`contract.md` tidak memuat endpoint wishlist). Begitu endpoint server ada,
- * provider ini pindah ke React Query dengan optimistic update, dan
- * localStorage hanya dipakai untuk tamu.
- *
- * `user.id` di sini sudah UUID asli dari `auth_users` (bukan email mock
- * seperti sebelum ISSUE-17), jadi key localStorage tidak lagi berubah kalau
- * user ganti email.
+ * Wishlist user — contract.md Bagian 35. Sumber kebenaran ada di server; tidak
+ * ada penyimpanan lokal sama sekali (keputusan D2 issue ini). Tamu yang menekan
+ * tombol wishlist diarahkan ke drawer sign in.
  */
 export function WishlistProvider({children}: {children: ReactNode}) {
-  const {user, isPending: authIsPending} = useAuth();
-  const [productIds, setProductIds] = useState<string[]>([]);
+  const {user} = useAuth();
+  const {toast} = useToast();
+  const {open} = useUi();
+  const queryClient = useQueryClient();
+  const userId = user?.id ?? null;
+  const skusKey = wishlistSkusKey(userId);
 
-  // Key localStorage yang datanya sedang direpresentasikan oleh `productIds`.
-  // Efek tulis di bawah menahan diri sampai ini cocok dengan key aktif —
-  // tanpa ini, array kosong dari state awal akan menimpa data tersimpan
-  // sebelum proses baca (async, lewat queueMicrotask) sempat selesai.
-  const loadedKeyRef = useRef<string | null>(null);
-  // Melacak user.id yang wishlist tamunya sudah pernah digabung, supaya
-  // penggabungan hanya terjadi sekali per transisi tamu→login.
-  const mergedForUserId = useRef<string | null>(null);
-
+  // Bersih-bersih sekali: wishlist versi lama disimpan di localStorage
+  // ("khena.wishlist.guest" / "khena.wishlist.<userId>"). Sejak issue ini data
+  // itu tidak pernah dibaca lagi, jadi jangan ditinggal menumpuk di browser user.
   useEffect(() => {
-    if (authIsPending) return;
-    const activeKey = user ? storageKey(user.id) : GUEST_STORAGE_KEY;
-
-    queueMicrotask(() => {
-      if (!user) {
-        mergedForUserId.current = null;
-        setProductIds(readList(GUEST_STORAGE_KEY));
-        loadedKeyRef.current = activeKey;
-        return;
+    try {
+      for (const key of Object.keys(window.localStorage)) {
+        if (key.startsWith("khena.wishlist.")) window.localStorage.removeItem(key);
       }
-
-      if (mergedForUserId.current === user.id) {
-        // Sudah pernah digabung untuk user ini — baca langsung, jangan
-        // gabung ulang (mis. saat productIds berubah karena toggle).
-        setProductIds(readList(activeKey));
-        loadedKeyRef.current = activeKey;
-        return;
-      }
-
-      // Baru login: gabungkan wishlist tamu (union, tanpa duplikat) ke
-      // wishlist user, lalu hapus key tamu — supaya item yang disimpan
-      // sebelum login tidak hilang diam-diam.
-      const guestIds = readList(GUEST_STORAGE_KEY);
-      const userIds = readList(activeKey);
-      const merged =
-        guestIds.length === 0 ? userIds : Array.from(new Set([...userIds, ...guestIds]));
-
-      if (guestIds.length > 0) {
-        window.localStorage.setItem(activeKey, JSON.stringify(merged));
-        window.localStorage.removeItem(GUEST_STORAGE_KEY);
-      }
-
-      mergedForUserId.current = user.id;
-      setProductIds(merged);
-      loadedKeyRef.current = activeKey;
-    });
-  }, [user, authIsPending]);
-
-  useEffect(() => {
-    if (authIsPending) return;
-    const activeKey = user ? storageKey(user.id) : GUEST_STORAGE_KEY;
-    if (loadedKeyRef.current !== activeKey) return;
-    window.localStorage.setItem(activeKey, JSON.stringify(productIds));
-  }, [productIds, user, authIsPending]);
-
-  const isSaved = useCallback(
-    (productId: string) => productIds.includes(productId),
-    [productIds]
-  );
-
-  const toggle = useCallback((productId: string): "saved" | "removed" => {
-    let outcome: "saved" | "removed" = "saved";
-    setProductIds((prev) => {
-      if (prev.includes(productId)) {
-        outcome = "removed";
-        return prev.filter((id) => id !== productId);
-      }
-      outcome = "saved";
-      return [...prev, productId];
-    });
-    return outcome;
+    } catch {
+      // localStorage bisa diblokir (private mode) — abaikan, ini hanya bersih-bersih.
+    }
   }, []);
 
+  const {data: savedSkus = []} = useQuery({
+    queryKey: skusKey,
+    // Tamu tidak punya wishlist server — jangan menembak endpoint yang pasti 401.
+    enabled: userId !== null,
+    queryFn: ({signal}) => wishlistRepository.listAllSkus(signal),
+  });
+
+  const addMutation = useMutation({
+    mutationFn: (sku: string) => wishlistRepository.add(sku),
+    onMutate: async (sku) => {
+      await queryClient.cancelQueries({queryKey: skusKey});
+      const previous = queryClient.getQueryData<string[]>(skusKey);
+      queryClient.setQueryData<string[]>(skusKey, (current = []) =>
+        current.includes(sku) ? current : [...current, sku]
+      );
+      return {previous};
+    },
+    onError: (error, _sku, context) => {
+      // `previous` bisa undefined kalau query belum pernah sukses — menyetel
+      // undefined menghapus cache-nya, dan onSettled di bawah mengambil ulang.
+      queryClient.setQueryData(skusKey, context?.previous);
+      toast(wishlistErrorMessage(error));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({queryKey: WISHLIST_KEY_PREFIX});
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (sku: string) => wishlistRepository.remove(sku),
+    onMutate: async (sku) => {
+      await queryClient.cancelQueries({queryKey: skusKey});
+      const previous = queryClient.getQueryData<string[]>(skusKey);
+      queryClient.setQueryData<string[]>(skusKey, (current = []) =>
+        current.filter((saved) => saved !== sku)
+      );
+      return {previous};
+    },
+    onError: (error, _sku, context) => {
+      queryClient.setQueryData(skusKey, context?.previous);
+      toast(wishlistErrorMessage(error));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({queryKey: WISHLIST_KEY_PREFIX});
+    },
+  });
+
+  const isSaved = useCallback((sku: string) => savedSkus.includes(sku), [savedSkus]);
+
+  const toggle = useCallback(
+    (sku: string): WishlistToggleOutcome => {
+      if (!user) {
+        open("account");
+        toast("Sign in to save pieces.");
+        return "signin-required";
+      }
+      if (savedSkus.includes(sku)) {
+        removeMutation.mutate(sku);
+        return "removed";
+      }
+      addMutation.mutate(sku);
+      return "saved";
+    },
+    [user, savedSkus, open, toast, addMutation, removeMutation]
+  );
+
   const value = useMemo<WishlistContextValue>(
-    () => ({productIds, isSaved, toggle}),
-    [productIds, isSaved, toggle]
+    () => ({savedSkus, isSaved, toggle}),
+    [savedSkus, isSaved, toggle]
   );
 
   return <WishlistContext.Provider value={value}>{children}</WishlistContext.Provider>;


### PR DESCRIPTION
## Ringkasan

Memindahkan seluruh sumber kebenaran wishlist ("Saved Pieces") dari localStorage ke backend, sesuai contract.md Bagian 35.

- `WishlistProvider` ditulis ulang: React Query + optimistic update/rollback, tanpa localStorage sama sekali. Tamu yang menekan tombol wishlist diarahkan ke drawer sign in (wishlist wajib login, tidak ada lagi wishlist tamu/penggabungan saat login).
- Wishlist dikunci pakai `sku` (`products.base_sku`), bukan `id` — `WishlistButton` dan tiga pemanggilnya (`ProductCard`, `ProductSummaryCard`, `FeaturedProductCard`) disesuaikan.
- `useSavedProducts` diganti total: `useInfiniteQuery` ke `GET /api/wishlists` berpaginasi (`limit=12`) dengan tombol **Load More**, bukan infinite scroll. `MOCK_PRODUCTS` tidak lagi dipakai di sini.
- Saved Pieces di `/account` dan `AccountDrawer` sekarang merender `ProductSummary` asli dari server lewat `RemoteImage`, dengan harga `priceAfterDiscount`.
- Repository baru (`HttpWishlistRepository`) didaftarkan di `infrastructure/repositories/client.ts` (bukan `index.ts`) supaya tidak menarik `server-only` ke bundle client.

## File baru
- `domain/entities/wishlist-item.ts`
- `domain/repositories/wishlist-repository.ts`
- `infrastructure/api/schemas/wishlist.ts`
- `infrastructure/api/mappers/wishlist.ts`
- `infrastructure/repositories/http-wishlist-repository.ts`

## File diubah
- `infrastructure/api/schemas/product-summary.ts` (schema di-export, reuse)
- `infrastructure/api/endpoints.ts` (blok `wishlists`)
- `infrastructure/repositories/client.ts` (daftarkan `wishlistRepository`)
- `presentation/providers/wishlist-provider.tsx`
- `presentation/components/product/wishlist-button.tsx`
- `presentation/components/product/product-card.tsx`
- `presentation/components/product/product-summary-card.tsx`
- `presentation/components/product/featured-product-card.tsx`
- `application/hooks/use-saved-products.ts`
- `presentation/components/account/account-page.tsx`
- `presentation/components/account/account-drawer.tsx`

## Verifikasi
- [x] `bunx tsc --noEmit` bersih
- [x] `bun run lint` bersih
- [x] `bun run build` bersih (tidak ada error `server-only`)
- [ ] Pengujian manual skenario Bagian 7 issue (butuh backend jalan + akun user + produk `published`)

## Di luar cakupan (sesuai issue)
Migrasi PDP `/product/[id]` & related products ke API, `/categories`, `/collections` carousel, cart, checkout, dan penghapusan `MockProductRepository`.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)